### PR TITLE
Resolve #145 Update Setup Process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ node_modules/
 .DS_Store
 
 public/assets/*
-db/import/*
 *.csv*
 .notes.md
 notes.txt

--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,8 @@ end
 
 group :development, :test do
   gem 'bullet', '4.14.10' # SQL diagnostics
+  gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source 'https://rubygems.org'
 
 ruby '2.3.1'
 
-gem 'bundler', '1.11.2'
+gem 'bundler'
 
-gem 'rails', '4.2.5.1'
+gem 'rails', '~> 4.2'
 
 # Database
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,11 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     puma (3.4.0)
     rack (1.6.4)
     rack-attack (5.0.1)
@@ -432,6 +437,8 @@ DEPENDENCIES
   periscope-activerecord
   pg
   pg_search
+  pry-byebug
+  pry-rails
   puma
   rack-attack
   rack-cors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0221)
     mini_portile2 (2.0.0)
-    minitest (5.8.4)
+    minitest (5.10.1)
     minitest-capybara (0.8.2)
       capybara (~> 2.2)
       minitest (~> 5.0)
@@ -329,9 +329,9 @@ GEM
       tilt (>= 1.1, < 3)
     scout_apm (2.1.1)
       rusage (~> 0.2.0)
-    seed-fu (2.3.5)
-      activerecord (>= 3.1, < 4.3)
-      activesupport (>= 3.1, < 4.3)
+    seed-fu (2.3.6)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
     sexp_processor (4.7.0)
     shellany (0.0.1)
     simplecov (0.11.2)
@@ -397,7 +397,7 @@ DEPENDENCIES
   brakeman
   browser
   bullet (= 4.14.10)
-  bundler (= 1.11.2)
+  bundler
   burgundy
   byebug
   capybara-slow_finder_errors
@@ -435,7 +435,7 @@ DEPENDENCIES
   puma
   rack-attack
   rack-cors
-  rails (= 4.2.5.1)
+  rails (~> 4.2)
   rails_12factor
   rake
   rb-fsevent
@@ -456,5 +456,8 @@ DEPENDENCIES
   wicked_pdf (~> 1.0)
   wkhtmltopdf-binary-edge
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -4,32 +4,12 @@
 [![Code Climate](https://codeclimate.com/github/MAPC/massbuilds/badges/gpa.svg)](https://codeclimate.com/github/MAPC/massbuilds)
 [![Test Coverage](https://codeclimate.com/github/MAPC/massbuilds/badges/coverage.svg)](https://codeclimate.com/github/MAPC/massbuilds/coverage)
 [![Inline docs](http://inch-ci.org/github/MAPC/massbuilds.png)](http://inch-ci.org/github/MAPC/massbuilds)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/MAPC/massbuilds?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 MassBuilds is a crowdsourced collection of recent ongoing and completed commercial and residential developments in Massachusetts.
 
 We're hard at work developing a new release that gives planners, developers, and enthusiasts advanced tools to find and understand developments, as well as the context in which they are built.
 
 MassBuilds is very important to the work we do at MAPC. High-quality data gathered from MassBuilds fuels our regional projections, which helps us understand the future of the Metro Boston region. Municipalities and other public agencies use MAPC's projections to set housing and economic development goals. The data you contribute here will contribute to a better Metro Boston region for everyone.
-
-### Actively working on:
-
-- :mag: __Search__ for developments quickly and easily. Start with one of our suggested searches to quickly find frequently searched-for developments. Then, export your developments as a spreadsheet or summary document.
-- :city_sunrise: __Understand the neighborhood__ through neighborhood context, including demographics and transportation information such as income breakdowns, public transit access, average parking ratios, and walkability scores.
-- :mailbox_with_mail: __Subscribe__ to developments, neighborhoods, or saved searches, and receive notifications when the developments or areas that interest you change.
-- :european_post_office: Create __organization pages__ to keep all of your team's developments in one place.
-- :trophy: __Gain reputation__ by contributing developments, improving data quality, or moderating developments.
-- :pushpin: __Claim__ developments that your development team is working on in the real world.
-- :triangular_flag_on_post: __Flag__ developments that you think need moderator attention.
-
-
-### Roadmap
-
-- :calendar: __Longitudinal area studies__ that show a picture of the recent past and near future.
-- :earth_americas: __Opportunity identification__ to help developers discover potential opportunities.
-- :parking: __Parking utilization data__, to help developers support a right-sized parking ratio for their proposed developments.
-- :link: __Integrations__ with other development & property web services, as well as common applications like Slack.
-- :left_right_arrow: __Public API and Webhooks__, to enable custom integrations.
 
 
 ### Developing
@@ -41,15 +21,23 @@ guard -w app lib test config
 ```
 
 
+### Installation
+
+First clone the repository. Then setup the database using the special instructions below. Finally you can start the app using `foreman start`. You should visit the app from your web browser by going to http://lvh.me:5000/. lvh.me points to localhost but allows the application to reference and resolve sub-domains when developing on localhost.
+
+#### Setting Up the Database
+
+You will need to have Postgres installed with PostGIS. On Mac OS X you can add PostGIS to Postgres with homebrew by running `brew install postgis`.
+
+To setup a working local database you can run the following command from the main repo:
+
+```
+createdb ddmodels2_development && \
+psql -d ddmodels2_development -c 'CREATE EXTENSION postgis;' && \
+psql ddmodels2_development < db/import/dd_models.sql && \
+rake database:correction_seq_id && rake db:migrate
+```
+
 ### Contact
 
-If you have a GitHub account, [get in touch with us via Gitter chat][gitter].
-
-Are you interested in learning more about MassBuilds? Contact Matt Cloyd, Web Developer at mcloyd@mapc.org.
-
-
-### Contributing
-
-Is there a feature you'd like to see? Would you like to get involved in a fairly complex Rails application? First, [get in touch on Gitter][gitter], and we'll go from there!
-
-[gitter]: https://gitter.im/MAPC/massbuilds
+Are you interested in learning more about MassBuilds? Contact Matt Zagaja, Web Developer at mzagaja@mapc.org.

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgis
   encoding: unicode
   pool: 5
-  database: <%= ENV.fetch 'DB_NAME', 'massbuilds_dev' %>
+  database: <%= ENV.fetch 'DB_NAME', 'ddmodels2_development' %>
   username: <%= ENV.fetch 'DB_USERNAME', nil %>
   password: <%= ENV.fetch 'DB_PASSWORD', nil %>
   host:     <%= ENV.fetch 'DB_PORT_5432_TCP_ADDR', 'localhost' %>

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,0 +1,8 @@
+namespace :database do
+    desc "Correction of sequences id"
+    task correction_seq_id: :environment do
+        ActiveRecord::Base.connection.tables.each do |t|
+            ActiveRecord::Base.connection.reset_pk_sequence!(t)
+        end
+    end
+end

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,8 +1,8 @@
 namespace :database do
-    desc "Correction of sequences id"
-    task correction_seq_id: :environment do
-        ActiveRecord::Base.connection.tables.each do |t|
-            ActiveRecord::Base.connection.reset_pk_sequence!(t)
-        end
+  desc 'Correction of sequences id'
+  task correction_seq_id: :environment do
+    ActiveRecord::Base.connection.tables.each do |t|
+      ActiveRecord::Base.connection.reset_pk_sequence!(t)
     end
+  end
 end


### PR DESCRIPTION
This commit brings the app into a state that allows a new developer to easily setup Massbuilds on their local machine. This fixes this by doing the following:

* Commits dd_models.sql, a sql dump from a known working development database to serve as a seed.
* Updates Gemfile and Gemfile.lock to not lock down bundler so users do not receive bundler related error messages.
* Updates .gitignore so we can commite dd_models.sql
* Adds a rake task to fix the sequence ids in the postgres database because the dd_models.sql import did not correctly set these in the local development database.
* Provides instructions in README.md so a new developer can setup an appropriate database.
* Updates database.yml to use the database name ddmodels2_development because using a different name did not allow us to correctly import our .sql file.
* Resolves #149  by removing the gitter chat link
* Resolves #150 by changing README to include Matt Zagaja's contact information.