### PR TITLE
Resolve #132 Remove Incorrect Export Message

### DIFF
--- a/searchapp/app/templates/application.hbs
+++ b/searchapp/app/templates/application.hbs
@@ -54,9 +54,6 @@
           <div class="header">
             Select format:
           </div>
-          <div class="content">
-            Note: Exports will be limited to the first 100 records            
-          </div>
           <div class="actions">
             <a href="/searches/{{search.id}}.csv" download class="ui positive approve red ok right labeled icon button">
               CSV

--- a/searchapp/app/templates/components/filters-menu.hbs
+++ b/searchapp/app/templates/components/filters-menu.hbs
@@ -45,9 +45,6 @@
   <div class="header">
     Select format:
   </div>
-  <div class="content">
-    Note: Exports will be limited to the first 100 records            
-  </div>
   <div class="actions">
     <a href="https://mapc-maps.carto.com/api/v2/sql?q={{sql_export}}&format=csv" download class="ui positive approve red ok right labeled icon button">
       Spreadsheet (CSV)


### PR DESCRIPTION
Since exports are not currently limited to the first 100 exports, this commit removes the text telling users that they are limited to the first 100 records.