### PR TITLE
Fixes #169 by fixing nearest transit stop feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ guard -w app lib test config
 
 First clone the repository. Then setup the database using the special instructions below. Finally you can start the app using `foreman start`. You should visit the app from your web browser by going to http://lvh.me:5000/. lvh.me points to localhost but allows the application to reference and resolve sub-domains when developing on localhost.
 
+Creating new developments requires obtaining an [MBTA API Key](http://realtime.mbta.com/portal) and setting MBTA_API_KEY to this key in your .env file.
+
 #### Setting Up the Database
 
 You will need to have Postgres installed with PostGIS. On Mac OS X you can add PostGIS to Postgres with homebrew by running `brew install postgis`.

--- a/lib/nearest_transit.rb
+++ b/lib/nearest_transit.rb
@@ -14,7 +14,7 @@ class NearestTransit
   private
 
   def stop_name
-    subway_station || bus_sotp
+    subway_station || bus_stop
   end
 
   def subway_station


### PR DESCRIPTION
Local development instances would not be able to find the nearest transit stop because it needed to access the MBTA API. This fixes this issue by adding instructions so a developer can get an MBTA API key. It also fixes a typo in the nearest_transit class.