### PR TITLE
Fix #159 by removing validations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,9 +30,6 @@ class User < ActiveRecord::Base
 
   has_many :subscriptions
 
-  validates :first_name, presence: true, if: :new_record?
-  validates :last_name,  presence: true, if: :new_record?
-
   enumerize :mail_frequency, in: [:never, :daily, :weekly],
     predicates: true, default: :weekly
 

--- a/app/views/memberships/admin.html.haml
+++ b/app/views/memberships/admin.html.haml
@@ -19,7 +19,10 @@
       %tbody
         - pending_memberships.each do |membership|
           %tr
-            %td= link_to "#{membership.user.first_name} #{membership.user.last_name} (View Profile)", membership.user
+            - if membership.user.first_name.present? || membership.user.last_name.present?
+              %td= link_to "#{membership.user.try(:first_name)} #{membership.user.try(:last_name)} (View Profile)", membership.user
+            - else
+              %td= link_to "#{membership.user.email} (View Profile)", membership.user
             %td
               = link_to approve_membership_path(membership), method: :put do
                 %button.ui.green.button
@@ -45,7 +48,7 @@
     %tbody
       - @memberships.map {|m| [m, m.user] }.each do |membership, user|
         %tr
-          %td= link_to "#{user.first_name} #{user.last_name} (#{user.email})", user
+          %td= link_to "#{user.try(:first_name)} #{user.try(:last_name)} (#{user.email})", user
           %td.collapsing
             = link_to user do
               %button.ui.basic.button

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -26,16 +26,6 @@ class UserTest < ActiveSupport::TestCase
     assert new_user.valid?, new_user.errors.full_messages
   end
 
-  test 'requires a first name' do
-    new_user.first_name = nil
-    assert_not new_user.valid?
-  end
-
-  test 'requires a last name' do
-    new_user.last_name = nil
-    assert_not new_user.valid?
-  end
-
   test 'hashes email before saving' do
     user.save
     assert_not_empty user.hashed_email


### PR DESCRIPTION
This removes the first and last name validations for users because users should not have to enter this information to have an account, and previous users that had not entered this information were getting errors when resetting their passwords. This commit fixes this problem by no longer validating first and last names. It also updates relevant tests and views to gracefully handle the lack of a first or last name from a user model.