### PR TITLE
Fix #124 by rendering proper layout

### DIFF
--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -1,6 +1,6 @@
 class DevelopmentsController < ApplicationController
 
-  layout 'search', only: [:index]
+  layout 'search', only: [:index, :new]
 
   before_action :load_record, only: [:show, :image, :edit]
   before_action :authenticate_user!, only: [:edit, :update]


### PR DESCRIPTION
A previews change removed the specialized Ember template layout and had it default to something else. It seems like it was some form of refactoring, so this adds the :new action back in. If we use Ember for the :edit action again, we need to make sure it renders the ‘search’ layout.