### PR TITLE
Fix #122 By Using Search API

### DIFF
--- a/app/resources/api/v1/searchable_resource.rb
+++ b/app/resources/api/v1/searchable_resource.rb
@@ -40,6 +40,11 @@ module API
         OpenStruct.new(geometry: {}, properties: { 'confidence' => 0 })
       end
 
+      def self.verify_key(key, context = nil)
+        key.delete!(',')
+        super(key, context)
+      end
+
       def self.wrap_with_resource(record)
         case record.class.name
         when 'Development'

--- a/app/resources/api/v1/searchable_resource.rb
+++ b/app/resources/api/v1/searchable_resource.rb
@@ -29,7 +29,7 @@ module API
       end
 
       def self.confident_in_location?(location)
-        location.properties['confidence'].to_f > 0.75
+        location.properties['confidence'].to_f > 0.6
       end
 
       def self.no_place?(search_results)

--- a/lib/mapzen_search.rb
+++ b/lib/mapzen_search.rb
@@ -27,7 +27,9 @@ class MapzenSearch
 
   def results
     # Array-ify nil caused by a URL error
-    Array(JSON.parse(response)['features']).map { |json| OpenStruct.new(json) }
+    parsed_response = Array(JSON.parse(response)['features'])
+    parsed_response.sort! { |result| result["properties"]["confidence"] }
+    parsed_response.map { |json| OpenStruct.new(json) }
   end
 
   def response

--- a/lib/mapzen_search.rb
+++ b/lib/mapzen_search.rb
@@ -36,12 +36,12 @@ class MapzenSearch
 
   def base
     @base ||= %W(
-      http://search.mapzen.com/v1/autocomplete
+      http://search.mapzen.com/v1/search
       ?api_key=#{ENV.fetch('MAPZEN_API_KEY')}
       &focus.point.lat=42.357&focus.point.lon=-71.056
       &sources=openstreetmap
       &layers=address,microhood,neighbourhood,macrohood
-      "&text="
+      &text=
     ).join.freeze
   end
 

--- a/lib/mapzen_search.rb
+++ b/lib/mapzen_search.rb
@@ -41,8 +41,6 @@ class MapzenSearch
       http://search.mapzen.com/v1/search
       ?api_key=#{ENV.fetch('MAPZEN_API_KEY')}
       &focus.point.lat=42.357&focus.point.lon=-71.056
-      &sources=openstreetmap
-      &layers=address,microhood,neighbourhood,macrohood
       &text=
     ).join.freeze
   end


### PR DESCRIPTION
The autocomplete API was not returning results from Mapzen with street addresses. This was happening for two reasons. The first is that the key we were giving it had commas, and commas throw exceptions, which is why we override the verify_key method to strip out commas. The second is we were using the autocomplete API which stops returning useful feature results when the strings get too specific. So we switched to the search API which does not have this issue.