### PR TITLE
Fix #192 by choosing most confident result

### DIFF
--- a/lib/mapzen_search.rb
+++ b/lib/mapzen_search.rb
@@ -20,7 +20,7 @@ class MapzenSearch
   end
 
   def result
-    results.first
+    results.last
   end
 
   private


### PR DESCRIPTION
While we expected sorting results by confidence to put the most confident result at the top of the list, ruby merely sorts the confidence from lowest to highest. This fixes #192 by correctly selecting the most confident result.