### PR TITLE
Resolve #203 Stop Requiring Commercial Sq Ft

### DIFF
--- a/app/models/concerns/development/validations.rb
+++ b/app/models/concerns/development/validations.rb
@@ -7,7 +7,6 @@ class Development
     included do
 
       validates :tothu,      presence: true
-      validates :commsf,     presence: true
       validates :year_compl, presence: true
 
       validates :creator,    presence: true

--- a/searchapp/app/templates/developments/forms/physical.hbs
+++ b/searchapp/app/templates/developments/forms/physical.hbs
@@ -21,7 +21,7 @@
         </td>
       </tr>
     <tr>
-      <td><div class="ui form"><div class="required field input"><label>{{#ui-popup tagName="label" content="Nonresidential share of commercial use."}}Commercial Square Feet <i class="help circle icon"></i>{{/ui-popup}}</label></div></div></td>
+      <td><div class="ui form"><div class="field input"><label>{{#ui-popup tagName="label" content="Nonresidential share of commercial use."}}Commercial Square Feet <i class="help circle icon"></i>{{/ui-popup}}</label></div></div></td>
       <td>
         <div class="ui input">
           {{input type="text" value=model.commsf}}


### PR DESCRIPTION
This commit removes the validation for commercial square footage and also removes the UI prompt noting that it is required.