### PR TITLE
Ie11 fix

### DIFF
--- a/app/views/developments/index.html.haml
+++ b/app/views/developments/index.html.haml
@@ -1,7 +1,11 @@
-= render_ember_app :searchapp do |head|
-  :javascript
-  
-    document.API_KEY = '#{current_user.try(:api_key)}'
-
+= render_ember_app :searchapp do |head, body|
   = head.append do
+    :javascript
+    
+      document.API_KEY = '#{current_user.try(:api_key)}'
+    = stylesheet_link_tag 'application'
+    = javascript_include_tag 'application'
     = csrf_meta_tags
+  = body.append do
+    #flash= render 'shared/flash'
+    = render 'shared/header'

--- a/app/views/developments/new.html.haml
+++ b/app/views/developments/new.html.haml
@@ -1,7 +1,11 @@
-= render_ember_app :searchapp do |head|
-  :javascript
-
-    document.API_KEY = '#{current_user.try(:api_key)}'
-
+= render_ember_app :searchapp do |head, body|
   = head.append do
+    :javascript
+    
+      document.API_KEY = '#{current_user.try(:api_key)}'
+    = stylesheet_link_tag 'application'
+    = javascript_include_tag 'application'
     = csrf_meta_tags
+  = body.append do
+    #flash= render 'shared/flash'
+    = render 'shared/header'

--- a/app/views/layouts/search.html.haml
+++ b/app/views/layouts/search.html.haml
@@ -1,13 +1,2 @@
 !!! 5
-%html
-  %head
-    %title MassBuilds
-    - style_opts = { media: 'all' }
-    = stylesheet_link_tag 'application', style_opts
-    = javascript_include_tag 'application'
-    = csrf_meta_tags
-
-  %body
-    #flash= render 'shared/flash'
-    = render 'shared/header'
-    = yield
+= yield

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -8,7 +8,7 @@
 # Configuration details:
 # https://github.com/airbrake/airbrake-ruby#configuration
 
-if ENV['AIRBRAKE_PROJECT_ID'] && ENV['AIRBRAKE_PROJECT_KEY']
+# if ENV['AIRBRAKE_PROJECT_ID'] && ENV['AIRBRAKE_PROJECT_KEY']
   Airbrake.configure do |c|
     # You must set both project_id & project_key. To find your project_id and
     # project_key navigate to your project's General Settings and copy the values
@@ -52,7 +52,7 @@ if ENV['AIRBRAKE_PROJECT_ID'] && ENV['AIRBRAKE_PROJECT_KEY']
     # https://github.com/airbrake/airbrake-ruby#blacklist_keys
     c.blacklist_keys = [/password/i, /key/i]
   end
-end
+# end
 # If Airbrake doesn't send any expected exceptions, we suggest to uncomment the
 # line below. It might simplify debugging of background Airbrake workers, which
 # can silently die.

--- a/searchapp/app/adapters/application.js
+++ b/searchapp/app/adapters/application.js
@@ -8,11 +8,11 @@ export default DS.JSONAPIAdapter.extend({
     if (token) {
       return {
         "Authorization": "Token " + token,
-        "Accept": "application/vnd.api+json; application/org.massbuilds.v1"
+        "Accept": "application/vnd.api+json"
       }
     } else {
       return {
-        "Accept": "application/vnd.api+json; application/org.massbuilds.v1"
+        "Accept": "application/vnd.api+json"
       }
     }
   }).volatile(),

--- a/searchapp/app/index.html
+++ b/searchapp/app/index.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
This includes commits from #223.

This fixes compatibility issues with IE 11, tested manually over Browserstack on windows 10 and 11, IE 11, 10, addressing #218 by allowing the app to render correctly. 

Some changes were made to the Ember app's Rails layout template, so the development New and Search views should be tested extensively. 