### PR TITLE
Resolve #84

### DIFF
--- a/ember/app/router.js
+++ b/ember/app/router.js
@@ -29,6 +29,7 @@ Router.map(function() {
     });
   });
   this.route('glossary');
+  this.route('faq');
 });
 
 export default Router;

--- a/ember/app/routes/faq.js
+++ b/ember/app/routes/faq.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/ember/app/styles/routes/_all.scss
+++ b/ember/app/styles/routes/_all.scss
@@ -1,4 +1,5 @@
 @import 'map';
 @import 'glossary';
+@import 'faq';
 
 @import 'map/all';

--- a/ember/app/styles/routes/faq.scss
+++ b/ember/app/styles/routes/faq.scss
@@ -1,0 +1,11 @@
+  .route.faq {
+    main {
+      width: 85%;
+      max-width: 700px;
+      min-height: 95vh;
+      margin: 0 auto;
+      padding: 20px 0 80px;
+
+      @include media('medium') { width: 92%; }
+    }
+  }

--- a/ember/app/templates/faq.hbs
+++ b/ember/app/templates/faq.hbs
@@ -1,0 +1,56 @@
+<section class="route faq">
+  <main>
+    <h1>MassBuilds: Frequently Asked Questions</h1>
+
+    <h2>What is MassBuilds?</h2>
+    <p>MassBuilds is a database with information on recent, current, and future developments in the Greater Boston region. The mapping feature on MassBuilds.com allows users to view developments spatially within the region. Both spatial (.shp, .geojson) and tabular (.csv) versions of the development data are available for download on our site.</p>
+
+    <h2>What sorts of data can I find in MassBuilds?</h2>
+    <p>MassBuilds does not merely track the existence of developments in the Greater Boston region, but has detailed information on these developments including but not limited to: project status, estimated year of completion, commercial square footage, number of housing units, number of parking spots, total stories and/or height, and a brief description for each development.</p>
+
+    <h2>How do I find a particular development that I am interested in?</h2>
+    <p>Developments are searchable by name or address. If you do not know either, you can search for a general location on the map and zoom in or out to look at developments in a certain area. In order to look at the details for a particular development, click on the blue dot demarking it on the map, then click on the name of the development that pops up in order to see full details.</p>
+
+    <h2>I’ve noticed some data is incomplete or out of date. What should I do?</h2>
+    <p>Our data has been vetted by the MassBuilds team at MAPC and has a high degree of accuracy, but in the rare case that the status or details of a particular development are out of date, you can propose an edit by clicking on the development, as long as you have created a MassBuilds account.</p>
+
+    <h2>There is a development that I am aware of but that is not currently in the MassBuilds database. How can I add it?</h2>
+    <p>We welcome user-added developments! On the top of the MassBuilds page is a “+” button, which allows users with MassBuilds accounts to propose new developments. When adding a new development, please be precise and include as much information as possible, including but not limited to commercial square footage, number of housing units, number of parking spaces, and a description field.</p>
+
+    <h2>How can access the entire dataset instead of looking at one development at a time?</h2>
+    <p>In the upper right hand corner of the MassBuilds map page is the “Export Results” tab. Clicking on this tab will allow you to download a spreadsheet or spatial data file with detailed information on all of the developments in MassBuilds. The PDF export option provides a summary report of developments categorized by their development status.</p>
+
+    <h2>I have a question that is not listed above or I am having trouble using MassBuilds. Who can I contact?</h2>
+    <p>We love to hear feedback from MassBuilds users and are eager to make the tool work best for planners, developers, and engaged citizens alike. Please contact us at MassBuilds@MAPC.org with any concerns, questions, or feedback you can offer us, and we will be sure to get back to you.</p>
+
+    <h1>How to use MassBuilds</h1>
+
+    <h2>Site Visitors with No Account</h2>
+    <p>If you are visiting the site and do not want to make an account, you can see project descriptions, browse our map, and filter projects by location or attribute.</p>
+
+    <h2>Registered Users</h2>
+    <p>Any site visitor can become a registered user by creating an account! Registered users may download data and suggest new developments and edits to projects that will be moderated and verified by MAPC staff before they are added to MassBuilds. We try to review moderations within a week, but can take longer.</p>
+    <p>To become a Registered User, simply signup for an account on MassBuilds with a personal email to receive your credentials. When you sign up, you will be asked if you are an official representative of a municipal or state governmental agency or relevant quasi-governmental agency—select no. </p>
+    <p>When you are logged in to your MassBuilds account, you will receive dashboard notifications on the status of your suggested additions and edits.</p>
+
+    <h2>Verified Users: Municipal Staff, Planning Board Members, Regional Planning Agencies, and other relevant State Agencies</h2>
+    <p>Members of Regional Planning Agencies and other relevant state/quasi-governmental agencies who are Verified Users may submit new developments and edit developments created by the same account without moderation from MAPC staff. We try to review moderations within a week, but can take longer.When you signup for an account on MassBuilds, you will be asked if you are an official representative of a municipal or state governmental agency or relevant quasi-governmental agency—select yes and enter your title and agency.You will then be asked if you would like to be a Verified User. If you select yes, your credentials will be verified by an MAPC staff member. Once verified, you will be able to add projects and edit your own developments without moderation by MAPC staff. You will not be able to moderate others’ developments.If you select no, you will be considered a “verified user”  and not receive unmoderated editing and adding access.</p>
+
+    <h2>Which projects should I add to MassBuilds?</h2>
+    <p>This dataset is meant to be inclusive of buildings only (for example street improvements would not be included). There’s no minimum size requirement for projects, but we ask that you only add projects that would be considered “impactful” to a community.</p>
+
+    <p>Still unsure if you should add it? Here are some general guidelines:</p>
+    <h3>Housing projects</h3>
+    <ul>
+      <li>Rural/suburban communities: >= 10 units</li>
+      <li>Urban communities: >= 20 units</li>
+    </ul>
+    <h3>Commercial projects</h3>
+    <ul>
+      <li>Rural/suburban communities: >= 20,000 sqft</li>
+      <li>Urban communities: >= 50,000 sqft</li>
+    </ul>
+    <h2>How do I add a project?</h2>
+    <p>Once you are logged in to your account, you will see an option to create a development on your dashboard.You are required to populate all fields marked with an * . You will not be given an option to submit a development until all required fields are populated. The required fields will change depending on the Status of the project (the further along the project, the more information is required).</p>
+  </main>
+</section>


### PR DESCRIPTION
This resolves #84 by adding a FAQ page to MassBuilds accessible at /faq. It just needs to be linked from somewhere and should maybe be double checked for styling.