### PR TITLE
Fix CSV Download

### DIFF
--- a/rails/app/models/development.rb
+++ b/rails/app/models/development.rb
@@ -63,10 +63,10 @@ class Development < ApplicationRecord
     CSV.generate(headers: true) do |csv|
       csv << attributes
       all.each do |development|
-        csv << attributes.map { |attr|
-          value = development.send(attr.gsub(/\,/,";"))
-          (value.is_a? String) ? value.gsub(/\n/,"").gsub(/\;/,",") : value
-        }
+        csv << attributes.map do |attr|
+          value = development.send(attr)
+          (value.is_a? String) ? value.gsub(/\n/,"").gsub(/\;/,",").gsub(/(^\d{5}$)/,"\"\\1\"") : value
+        end
       end
     end
   end

--- a/rails/app/models/development.rb
+++ b/rails/app/models/development.rb
@@ -65,7 +65,7 @@ class Development < ApplicationRecord
       all.each do |development|
         csv << attributes.map do |attr|
           value = development.send(attr)
-          (value.is_a? String) ? value.gsub(/\n/,"").gsub(/\;/,",").gsub(/(^\d{5}$)/,"\"\\1\"") : value
+          (value.is_a? String) ? value.gsub(/\n/,"").gsub(/\;/,",").gsub(/(^\d{5}$)/,"=\"\\1\"") : value
         end
       end
     end


### PR DESCRIPTION
This fixes the CSV download by replacing all zip codes with a quoted version of them so that Microsoft Excel will not munge the leading zeros.

It also refactors the syntax of the CSV generation to no longer uselessly gsub commas into semicolons in the attribute names.