### PR TITLE
Prevent zoom when entering the create dev screen from the searchbar

### DIFF
--- a/ember/app/components/mapbox-map.js
+++ b/ember/app/components/mapbox-map.js
@@ -403,7 +403,13 @@ export default class extends Component {
           type: 'FeatureCollection',
           features: filteredFeatures,
         });
-        this.mapboxglMap.setPaintProperty('filtered', 'circle-stroke-opacity', activeCircleStrokeOpacity);
+        Object.entries(this.generatePaintProperties(
+          true,
+          highContrast,
+          isMuted
+        )).forEach(([property, value]) => {
+          this.mapboxglMap.setPaintProperty('filtered', property, value);
+        });
       } else {
         this.mapboxglMap.addLayer({
           id: 'filtered',

--- a/ember/app/components/mapbox-map.js
+++ b/ember/app/components/mapbox-map.js
@@ -274,11 +274,13 @@ export default class extends Component {
     const data = mapService.get('filteredData').length
         ? mapService.get('filteredData')
         : mapService.get('stored');
-    const fitBounds = data.reduce(
-    (bounds, datum) => bounds.extend([datum.get('longitude'), datum.get('latitude')]),
-      new mapboxgl.LngLatBounds()
-    );
-    this.mapboxglMap.fitBounds(fitBounds, { padding: 40 });
+    if (data.toArray().length > 0) {
+      const fitBounds = data.reduce(
+      (bounds, datum) => bounds.extend([datum.get('longitude'), datum.get('latitude')]),
+        new mapboxgl.LngLatBounds()
+      );
+      this.mapboxglMap.fitBounds(fitBounds, { padding: 40 });
+    }
   }
 
   generatePaintProperties(selected, highContrast, isMuted) {

--- a/ember/app/templates/components/search-bar.hbs
+++ b/ember/app/templates/components/search-bar.hbs
@@ -28,7 +28,7 @@
     {{/if}}
 
     {{#if (and hasPermissions (lt searchListCount 6))}}
-      {{#link-to 'map.developments.create' click=(action selectItem)}}
+      {{#link-to 'map.developments.create'}}
         <li class="create-new">
           Can't find what you're looking for? <b>Click here</b> to submit
           a development to the database.


### PR DESCRIPTION
Resolves #125. This removes the unnecessary onClick from the search bar menu which takes the user to the new development page. The onClick had been adding an undefined filter parameter which triggered the map to refocus.