### PR TITLE
Fix column typo to remove correct d_n_trnsit column

### DIFF
--- a/rails/app/models/development.rb
+++ b/rails/app/models/development.rb
@@ -55,7 +55,7 @@ class Development < ApplicationRecord
       'forty_b',
       'residential',
       'commercial',
-      'd_n_transit'
+      'd_n_trnsit'
     ]
 
     attributes = self.column_names


### PR DESCRIPTION
Turns out, we misspelled the column we wanted to remove because these column names have inconsistent abbreviation patterns.
Resolves #100 