### PR TITLE
Edit development location

### DIFF
--- a/ember/app/components/mapbox-map.js
+++ b/ember/app/components/mapbox-map.js
@@ -332,8 +332,6 @@ export default class extends Component {
   jumpTo(mapService) {
     const dev = mapService.get('viewing');
     if (dev) {
-      // const coordinates = [dev.get('longitude') - .00125, dev.get('latitude')];
-      // const bounds = new mapboxgl.LngLatBounds([coordinates, coordinates]);
       const bounds = this.getBoundsFromCoordinates([dev.get('longitude'), dev.get('latitude')])
       this.mapboxglMap.fitBounds(bounds);
     }

--- a/ember/app/routes/map/developments/create.js
+++ b/ember/app/routes/map/developments/create.js
@@ -14,6 +14,7 @@ export default class extends Route {
   activate(transition) {
     this.get('map').setSelectionMode(true);
   }
+
   @action
   deactivate(transition) {
     this.get('map').setSelectionMode(false);

--- a/ember/app/routes/map/developments/development/edit.js
+++ b/ember/app/routes/map/developments/development/edit.js
@@ -1,4 +1,17 @@
 import Route from '@ember/routing/route';
+import { service } from 'ember-decorators/service';
+
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend(AuthenticatedRouteMixin);
+export default class extends Route.extend(AuthenticatedRouteMixin) {
+
+  @service map
+
+  activate(transition) {
+    this.get('map').setSelectionMode(true);
+  }
+
+  deactivate(transition) {
+    this.get('map').setSelectionMode(false);
+  }
+}

--- a/rails/app/models/edit.rb
+++ b/rails/app/models/edit.rb
@@ -219,8 +219,8 @@ class Edit < ApplicationRecord
 
   def update_development
     if development
-      # Skip validations since the Edit model does this for us
-      development.update_columns(proposed_changes)
+      # Make sure we call the lifecycle callbacks to update calculated values
+      development.update(proposed_changes)
     else
       merged_changes = proposed_changes.merge(user_id: user.id)
       development = Development.new(merged_changes)


### PR DESCRIPTION
Resolves #143 (mostly). This PR extends location editing to the development edit panel, however, as #143 suggested, this iteration does not include a safeguard to prevent a user from accidentally moving the location. A user would have to "cancel" their edits to undo an accidental location nudge.