### PR TITLE
Improve search-bar algorithm via keywords

### DIFF
--- a/ember/app/components/search-bar.js
+++ b/ember/app/components/search-bar.js
@@ -66,19 +66,32 @@ export default class extends Component {
     let filtered = {};
 
     if (searchQuery.length >= 2) {
+      const queryWords = searchQuery.toLowerCase().split(' ');
+
       sortOrder.forEach(col => {
-        let name = filters[col].name;
+        var name = filters[col].name;
 
         filtered[name] = this.get(col)
-                            .filter(row => row.value.toLowerCase().startsWith(searchQuery))
-                            .map(row => {
-                              return { ...row , name, col }
-                            });
+                            .filter(record => {
+                              var keywords = record.value.toLowerCase().split(' ');
+
+                              return (
+                                keywords
+                                ? queryWords.every(queryWord => (
+                                  keywords.any(keyword => keyword.startsWith(queryWord))
+                                ))
+                                : false
+                              );
+                            })
+                            .map(row => ({ ...row , name, col }));
       });
     }
     return filtered;
   }
 
+  filterMatches(record) {
+
+  }
 
   @computed('searchList')
   get searchListCount() {

--- a/ember/app/components/search-bar.js
+++ b/ember/app/components/search-bar.js
@@ -83,15 +83,12 @@ export default class extends Component {
                                 : false
                               );
                             })
-                            .map(row => ({ ...row , name, col }));
+                            .map(row => ({ ...row, name, col }));
       });
     }
     return filtered;
   }
 
-  filterMatches(record) {
-
-  }
 
   @computed('searchList')
   get searchListCount() {


### PR DESCRIPTION
This PR resolves #93 by checking query words against keywords instead of matching the string from start to finish. This means that you can type 'riv' and get 'Fall River' where before you would have to type 'fal' to get that same result.