### PR TITLE
Handle null address parts and solve validation form bug

### DIFF
--- a/ember/app/components/development-form.js
+++ b/ember/app/components/development-form.js
@@ -146,7 +146,6 @@ export default class extends Component {
 
   @action
   updateCommsf(fieldName) {
-    console.log(fieldName);
     this.checkForUpdated(fieldName);
 
     const sum = this.sumProperties(...this.get('commsfFields'), 'editing.unkSqft');

--- a/ember/app/components/development-form.js
+++ b/ember/app/components/development-form.js
@@ -146,6 +146,7 @@ export default class extends Component {
 
   @action
   updateCommsf(fieldName) {
+    console.log(fieldName);
     this.checkForUpdated(fieldName);
 
     const sum = this.sumProperties(...this.get('commsfFields'), 'editing.unkSqft');

--- a/ember/app/controllers/map/developments/create.js
+++ b/ember/app/controllers/map/developments/create.js
@@ -54,8 +54,7 @@ export default class extends Controller {
       })
       .catch(e => {
         const column = this.findMistake(e);
-
-        if (column !== null) {
+        if (column) {
           const fieldName = filters[column].name;
           this.get('notifications').error(`The ${fieldName} field has invalid data.`);
         }

--- a/ember/app/models/development.js
+++ b/ember/app/models/development.js
@@ -79,8 +79,10 @@ export default class extends DS.Model {
   @computed('address', 'municipal', 'state', 'zipCode')
   get fullAddress() {
     const props = this.getProperties('address', 'municipal', 'state', 'zipCode');
-
-    return `${props.address}, ${props.municipal}, ${props.state} ${props.zipCode}`;
+    const address = props.address ? props.address : 'Unknown Address';
+    const municipal = props.municipal ? props.municipal : 'Unknown City';
+    const zipCode = props.zipCode ? props.zipCode : '';
+    return `${address}, ${municipal}, ${props.state || 'MA'} ${zipCode}`;
   }
 
 }

--- a/ember/app/models/development.js
+++ b/ember/app/models/development.js
@@ -79,9 +79,9 @@ export default class extends DS.Model {
   @computed('address', 'municipal', 'state', 'zipCode')
   get fullAddress() {
     const props = this.getProperties('address', 'municipal', 'state', 'zipCode');
-    const address = props.address ? props.address : 'Unknown Address';
-    const municipal = props.municipal ? props.municipal : 'Unknown City';
-    const zipCode = props.zipCode ? props.zipCode : '';
+    const address = props.address || 'Unknown Address';
+    const municipal = props.municipal || 'Unknown City';
+    const zipCode = props.zipCode || '';
     return `${address}, ${municipal}, ${props.state || 'MA'} ${zipCode}`;
   }
 

--- a/ember/app/templates/components/development-form.hbs
+++ b/ember/app/templates/components/development-form.hbs
@@ -31,7 +31,7 @@
           id="development_name"
           value=editing.name
           placeholder="Development Name"
-          key-up=(action checkForUpdated 'name')
+          input=(action checkForUpdated 'name')
         }}
       </div>
 
@@ -56,7 +56,7 @@
 
       <div class="form-row secondary project-url">
         <img src="/assets/images/link.svg">
-        {{input value=editing.prjUrl placeholder="Project Website" key-up=(action checkForUpdated 'prjUrl')}}
+        {{input value=editing.prjUrl placeholder="Project Website" input=(action checkForUpdated 'prjUrl')}}
       </div>
 
     </div>
@@ -68,7 +68,7 @@
           <div class="column">
             <div class="field">
               <label>{{defined-term key='DEVELOPER'}}</label>
-              {{input value=editing.devlper placeholder="Enter Developer Name" key-up=(action checkForUpdated 'devlper')}}
+              {{input value=editing.devlper placeholder="Enter Developer Name" input=(action checkForUpdated 'devlper')}}
             </div>
             {{#if model.user}}
               <div class="field">
@@ -92,7 +92,7 @@
               <label class="required">
                 {{defined-term key='DESCRIPTION'}}
               </label>
-              <p>{{textarea value=editing.descr class="required-field" placeholder="Enter Description" key-up=(action checkForUpdated 'descr')}}</p>
+              <p>{{textarea value=editing.descr class="required-field" placeholder="Enter Description" input=(action checkForUpdated 'descr')}}</p>
             </div>
           </div>
         </div>
@@ -123,7 +123,7 @@
               <label for="yearCompl" class="required">
                 {{defined-term key='YEAR_COMPLETE'}}
               </label>
-              {{input value=editing.yearCompl class="required-field" placeholder="Enter here" key-up=(action checkForUpdated 'yearCompl')}}
+              {{input value=editing.yearCompl class="required-field" placeholder="Enter here" input=(action checkForUpdated 'yearCompl')}}
             </div>
 
             <div class="field">
@@ -135,14 +135,14 @@
               <label for="totalCost">
                 {{defined-term key='COST_OF_CONSTRUCTION'}}
               </label>
-              ${{input value=editing.totalCost placeholder="Enter here" key-up=(action checkForUpdated 'totalCost')}}
+              ${{input value=editing.totalCost placeholder="Enter here" input=(action checkForUpdated 'totalCost')}}
             </div>
 
             <div class="field">
               <label for="prjarea">
                 {{defined-term key='PROJECT_AREA'}}
               </label>
-              {{input value=editing.prjarea placeholder="Enter here" key-up=(action checkForUpdated 'prjarea')}}
+              {{input value=editing.prjarea placeholder="Enter here" input=(action checkForUpdated 'prjarea')}}
             </div>
           </div>
 
@@ -151,21 +151,21 @@
               <label for="height">
                 {{defined-term key='HEIGHT'}}
               </label>
-              {{input value=editing.height placeholder="Enter here" key-up=(action checkForUpdated 'height')}}
+              {{input value=editing.height placeholder="Enter here" input=(action checkForUpdated 'height')}}
             </div>
 
             <div class="field">
               <label for="stories">
                 {{defined-term key='STORIES'}}
               </label>
-              {{input value=editing.stories placeholder="Enter here" key-up=(action checkForUpdated 'stories')}}
+              {{input value=editing.stories placeholder="Enter here" input=(action checkForUpdated 'stories')}}
             </div>
 
             <div class="field">
               <label for="onsitepark">
                 {{defined-term key='PARKING_SPACES'}}
               </label>
-              {{input value=editing.onsitepark placeholder="Enter here" key-up=(action checkForUpdated 'onsitepark')}}
+              {{input value=editing.onsitepark placeholder="Enter here" input=(action checkForUpdated 'onsitepark')}}
             </div>
 
             <div class="field">
@@ -231,7 +231,7 @@
               <label for="gqpop">
                 {{defined-term key='GROUP_QUARTERS_POPULATION'}}
               </label>
-              {{input value=editing.gqpop placeholder="Enter here" key-up=(action checkForUpdated 'gqpop')}}
+              {{input value=editing.gqpop placeholder="Enter here" input=(action checkForUpdated 'gqpop')}}
             </div>
           </div>
           <div class="column">
@@ -273,7 +273,7 @@
 
             <tr>
               <td><label for="singfamhu">Single Family</label></td>
-              <td>{{input value=editing.singfamhu placeholder=0 key-up=(action updateHu 'singfamhu')}}</td>
+              <td>{{input value=editing.singfamhu placeholder=0 input=(action updateHu 'singfamhu')}}</td>
               <td>
                 {{#if (gt editing.hu 0)}}
                   {{round (mult 100 (div editing.singfamhu editing.hu))}}%
@@ -285,7 +285,7 @@
 
             <tr>
               <td><label for="smmultifam">Small Multi-family</label></td>
-              <td>{{input value=editing.smmultifam placeholder=0 key-up=(action updateHu 'smmultifam')}}</td>
+              <td>{{input value=editing.smmultifam placeholder=0 input=(action updateHu 'smmultifam')}}</td>
               <td>
                 {{#if (gt editing.hu 0)}}
                   {{round (mult 100 (div editing.smmultifam editing.hu))}}%
@@ -297,7 +297,7 @@
 
             <tr>
               <td><label for="lgmultifam">Large Multi-family</label></td>
-              <td>{{input value=editing.lgmultifam placeholder=0 key-up=(action updateHu 'lgmultifam')}}</td>
+              <td>{{input value=editing.lgmultifam placeholder=0 input=(action updateHu 'lgmultifam')}}</td>
               <td>
                 {{#if (gt editing.hu 0)}}
                   {{round (mult 100 (div editing.lgmultifam editing.hu))}}%
@@ -309,7 +309,7 @@
 
             <tr>
               <td>Unknown</td>
-              <td>{{input value=editing.unknownhu placeholder=0 key-up=(action updateHu 'unknownhu')}}</td>
+              <td>{{input value=editing.unknownhu placeholder=0 input=(action updateHu 'unknownhu')}}</td>
               <td>
                 {{#if (gt editing.hu 0)}}
                   {{round (mult 100 (div editing.unknownhu editing.hu))}}%
@@ -323,7 +323,7 @@
 
             <tr>
               <td><label for="units1bd">Studio/1 Bedroom</label></td>
-              <td>{{input value=editing.units1bd placeholder=0 key-up=(action updateHu 'units1bd')}}</td>
+              <td>{{input value=editing.units1bd placeholder=0 input=(action updateHu 'units1bd')}}</td>
               <td>
                 {{#if (gt editing.hu 0)}}
                   {{round (mult 100 (div editing.units1bd editing.hu))}}%
@@ -335,7 +335,7 @@
 
             <tr>
               <td><label for="units2bd">2 Bedroom</label></td>
-              <td>{{input value=editing.units2bd placeholder=0 key-up=(action updateHu 'units2bd')}}</td>
+              <td>{{input value=editing.units2bd placeholder=0 input=(action updateHu 'units2bd')}}</td>
               <td>
                 {{#if (gt editing.hu 0)}}
                   {{round (mult 100 (div editing.units2bd editing.hu))}}%
@@ -347,7 +347,7 @@
 
             <tr>
               <td><label for="units3bd">3 Bedroom</label></td>
-              <td>{{input value=editing.units3bd placeholder=0 key-up=(action updateHu 'units3bd')}}</td>
+              <td>{{input value=editing.units3bd placeholder=0 input=(action updateHu 'units3bd')}}</td>
               <td>
                 {{#if (gt editing.hu 0)}}
                   {{round (mult 100 (div editing.units3bd editing.hu))}}%
@@ -384,7 +384,7 @@
 
             <tr>
               <td><label for="affU30">Units &lt;30% AMI</label></td>
-              <td>{{input value=editing.affU30 placeholder=0 key-up=(action updateAffrdUnit 'affU30')}}</td>
+              <td>{{input value=editing.affU30 placeholder=0 input=(action updateAffrdUnit 'affU30')}}</td>
               <td>
                 {{#if (gt editing.affrdUnit 0)}}
                   {{round (mult 100 (div editing.affU30 editing.affrdUnit))}}%
@@ -396,7 +396,7 @@
 
             <tr>
               <td><label for="aff3050">Units 30-50% AMI</label></td>
-              <td>{{input value=editing.aff3050 placeholder=0 key-up=(action updateAffrdUnit 'aff3050')}}</td>
+              <td>{{input value=editing.aff3050 placeholder=0 input=(action updateAffrdUnit 'aff3050')}}</td>
               <td>
                 {{#if (gt editing.affrdUnit 0)}}
                   {{round (mult 100 (div editing.aff3050 editing.affrdUnit))}}%
@@ -408,7 +408,7 @@
 
             <tr>
               <td><label for="aff5080">Units 50-80% AMI</label></td>
-              <td>{{input value=editing.aff5080 placeholder=0 key-up=(action updateAffrdUnit 'aff5080')}}</td>
+              <td>{{input value=editing.aff5080 placeholder=0 input=(action updateAffrdUnit 'aff5080')}}</td>
               <td>
                 {{#if (gt editing.affrdUnit 0)}}
                   {{round (mult 100 (div editing.aff5080 editing.affrdUnit))}}%
@@ -420,7 +420,7 @@
 
             <tr>
               <td><label for="aff80p">Units 80-100% AMI</label></td>
-              <td>{{input value=editing.aff80p placeholder=0 key-up=(action updateAffrdUnit 'aff80p')}}</td>
+              <td>{{input value=editing.aff80p placeholder=0 input=(action updateAffrdUnit 'aff80p')}}</td>
               <td>
                 {{#if (gt editing.affrdUnit 0)}}
                   {{round (mult 100 (div editing.aff80p editing.affrdUnit))}}%
@@ -432,7 +432,7 @@
 
             <tr>
               <td>Unknown</td>
-              <td>{{input value=editing.affUnknown placeholder=0 key-up=(action updateAffrdUnit 'affUnknown')}}</td>
+              <td>{{input value=editing.affUnknown placeholder=0 input=(action updateAffrdUnit 'affUnknown')}}</td>
               <td>
                 {{#if (gt editing.affrdUnit 0)}}
                   {{round (mult 100 (div editing.affUnknown editing.affrdUnit))}}%
@@ -454,7 +454,7 @@
               <label for="rptdemp">
                 {{defined-term key='REPORTED_EMPLOYMENT'}}
               </label>
-              {{input value=editing.rptdemp placeholder="Enter here" key-up=(action checkForUpdated 'rptdemp')}}
+              {{input value=editing.rptdemp placeholder="Enter here" input=(action checkForUpdated 'rptdemp')}}
             </div>
           </div>
 
@@ -463,14 +463,14 @@
               <label for="hotelrms">
                 {{defined-term key='HOTEL_ROOMS'}}
               </label>
-              {{input value=editing.hotelrms placeholder="Enter here" key-up=(action checkForUpdated 'hotelrms')}}
+              {{input value=editing.hotelrms placeholder="Enter here" input=(action checkForUpdated 'hotelrms')}}
             </div>
 
             <div class="field">
               <label for="publicsqft">
                 {{defined-term key='PUBLIC_AREA'}}
               </label>
-              {{input value=editing.publicsqft placeholder="Enter here" key-up=(action checkForUpdated 'publicsqft')}}
+              {{input value=editing.publicsqft placeholder="Enter here" input=(action checkForUpdated 'publicsqft')}}
             </div>
           </div>
         </div>
@@ -515,7 +515,7 @@
                   {{defined-term key='RETAIL_AREA'}}
                 </label>
               </td>
-              <td>{{input value=editing.retSqft placeholder=0 key-up=(action updateCommsf 'retSqft')}}</td>
+              <td>{{input value=editing.retSqft placeholder=0 input=(action updateCommsf 'retSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.retSqft editing.commsf))}}%
@@ -531,7 +531,7 @@
                   {{defined-term key='OFFICE_MEDICAL_AREA'}}
                 </label>
               </td>
-              <td>{{input value=editing.ofcmdSqft placeholder=0 key-up=(action updateCommsf 'ofcmdSqft')}}</td>
+              <td>{{input value=editing.ofcmdSqft placeholder=0 input=(action updateCommsf 'ofcmdSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.ofcmdSqft editing.commsf))}}%
@@ -547,7 +547,7 @@
                   {{defined-term key='INDUSTRIAL_MANUFACTURING_AREA'}}
                 </label>
               </td>
-              <td>{{input value=editing.indmfSqft placeholder=0 key-up=(action updateCommsf 'indmfSqft')}}</td>
+              <td>{{input value=editing.indmfSqft placeholder=0 input=(action updateCommsf 'indmfSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.indmfSqft editing.commsf))}}%
@@ -563,7 +563,7 @@
                   {{defined-term key='WAREHOUSE_SHIPPING_AREA'}}
                 </label>
               </td>
-              <td>{{input value=editing.whsSqft placeholder=0 key-up=(action updateCommsf 'whsSqft')}}</td>
+              <td>{{input value=editing.whsSqft placeholder=0 input=(action updateCommsf 'whsSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.whsSqft editing.commsf))}}%
@@ -579,7 +579,7 @@
                   {{defined-term key='RESEARCH_DEVELOPMENT_AREA'}}
                 </label>
               </td>
-              <td>{{input value=editing.rndSqft placeholder=0 key-up=(action updateCommsf 'rndSqft')}}</td>
+              <td>{{input value=editing.rndSqft placeholder=0 input=(action updateCommsf 'rndSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.rndSqft editing.commsf))}}%
@@ -595,7 +595,7 @@
                   {{defined-term key='EDUCATIONAL_INSTITUTIONAL_AREA'}}
                 </label>
               </td>
-              <td>{{input value=editing.eiSqft placeholder=0 key-up=(action updateCommsf 'eiSqft')}}</td>
+              <td>{{input value=editing.eiSqft placeholder=0 input=(action updateCommsf 'eiSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.eiSqft editing.commsf))}}%
@@ -611,7 +611,7 @@
                   {{defined-term key='HOTEL_ROOM_AREA'}}
                 </label>
               </td>
-              <td>{{input value=editing.hotelSqft placeholder=0 key-up=(action updateCommsf 'hotelSqft')}}</td>
+              <td>{{input value=editing.hotelSqft placeholder=0 input=(action updateCommsf 'hotelSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.hotelSqft editing.commsf))}}%
@@ -627,7 +627,7 @@
                   {{defined-term key='OTHER_AREA'}}
                 </label>
               </td>
-              <td>{{input value=editing.otherSqft placeholder=0 key-up=(action updateCommsf 'otherSqft')}}</td>
+              <td>{{input value=editing.otherSqft placeholder=0 input=(action updateCommsf 'otherSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.otherSqft editing.commsf))}}%
@@ -641,7 +641,7 @@
               <td>
                 {{defined-term key='UNKNOWN_AREA'}}
               </td>
-              <td>{{input value=editing.unkSqft placeholder=0 key-up=(action updateCommsf 'unkSqft')}}</td>
+              <td>{{input value=editing.unkSqft placeholder=0 input=(action updateCommsf 'unkSqft')}}</td>
               <td>
                 {{#if (gt editing.commsf 0)}}
                   {{round (mult 100 (div editing.unkSqft editing.commsf))}}%

--- a/rails/app/controllers/developments_controller.rb
+++ b/rails/app/controllers/developments_controller.rb
@@ -56,7 +56,7 @@ class DevelopmentsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.jsonapi { head :bad_request }
+        format.jsonapi { render json: @development.errors.full_messages, status: :bad_request }
       end
     end
   end


### PR DESCRIPTION
Apparently key-up events can be unreliable if fired very quickly. When a user enters values very quickly (like a bunch of 0s in quick succession), a key-up event can be missed. In this case, a key-up event being missed means that a value doesn't end up in the proposedChanges even though it is detected by the client-side validations because the value was properly changed.

Resolves #94 which we previously thought was un-reproducable.

Also resolves part of @arouault 's confusion in #183