### PR TITLE
Exclude deleted_at from downloads

### DIFF
--- a/rails/app/models/development.rb
+++ b/rails/app/models/development.rb
@@ -58,7 +58,8 @@ class Development < ApplicationRecord
       'forty_b',
       'residential',
       'commercial',
-      'd_n_trnsit'
+      'd_n_trnsit',
+      'deleted_at'
     ]
 
     attributes = self.column_names


### PR DESCRIPTION
Resolves #195.

# Why is this change necessary?
`deleted_at` is a background property for our database administration.
