### PR TITLE
Remove decimal places from total cost of development

### DIFF
--- a/ember/app/templates/map/developments/development/index.hbs
+++ b/ember/app/templates/map/developments/development/index.hbs
@@ -99,7 +99,7 @@
                     {{defined-term key="COST_OF_CONSTRUCTION" labelOverride="Cost"}}
                   </label>
                   {{#if model.totalCost}}
-                    ${{number-format model.totalCost}}
+                    ${{number-format model.totalCost decimals=0}}
                   {{else}}
                     <span class="unknown">Unknown</span>
                   {{/if}}


### PR DESCRIPTION
Resolves #196.

**Why is this change necessary?**
In a multi-million dollar development, decimal places both look silly, and (at first glance) can look like two extra orders of magnitude.
