### PR TITLE
Show MAPC users as MAPC Staff

### DIFF
--- a/ember/app/models/user.js
+++ b/ember/app/models/user.js
@@ -25,4 +25,10 @@ export default class extends DS.Model {
     return `${firstName} ${lastName}`;
   }
 
+  @computed('firstName', 'lastName', 'email')
+  get displayName() {
+    const { fullName, email } = this.getProperties('fullName', 'email');
+    return email.endsWith('mapc.org') ? 'MAPC Staff' : fullName;
+  }
+
 }

--- a/ember/app/templates/map/developments/development/index.hbs
+++ b/ember/app/templates/map/developments/development/index.hbs
@@ -51,7 +51,7 @@
                     {{#if (eq model.user.fullName 'undefined undefined')}}
                       {{loading-spinner message="Loading Creator" isLoading=true}}
                     {{else}}
-                      {{model.user.fullName}}
+                      {{model.user.displayName}}
                     {{/if}}
                   </span>
                 </div>


### PR DESCRIPTION
Resolves #124.

**Why is this change necessary?**
"Importer Bot" is not a user friendly name for a development creator.

**How does it address the issue?**
Development details list a development's creator as "MAPC Staff" if their email ends in mapc.org.