### PR TITLE
Remove filterData set that was overwriting filtered data

### DIFF
--- a/ember/app/components/mapbox-map.js
+++ b/ember/app/components/mapbox-map.js
@@ -44,7 +44,8 @@ export default class extends Component {
     this.mapboxglMap = new mapboxgl.Map({
       container: this.get('element'),
       style: mapStyle,
-      // maxBounds: [[-75.5, 39], [-67, 45]],
+      center: [-71.061391, 42.355107],
+      zoom: 10,
       maxBounds: [[-100, 20], [-40, 60]],
       dragRotate: false,
       pitchWithRotate: false,

--- a/ember/app/services/map.js
+++ b/ember/app/services/map.js
@@ -37,9 +37,6 @@ export default class extends Service {
 
     this.get('store').query('development', { trunc: true }).then(results => {
       this.set('stored', results.toArray());
-      // FilteredData must be explicitly set to trigger the map's observer so
-      // that it will display all of the stored data.
-      this.set('filteredData', []);
       this.set('storedBounds', mapboxgl.LngLatBounds.convert(results.map(result => new mapboxgl.LngLat(result.get('longitude'), result.get('latitude')))));
     });
   }
@@ -59,7 +56,6 @@ export default class extends Service {
     }
     else {
       this.get('notifications').show('Updating map', { duration: 2000 });
-
       this.set('pad', .1);
       this.get('store')
           .query('development', query)


### PR DESCRIPTION
Resolves #193.

**IMPORTANT: When reviewing, ensure that #152 remains resolved.**

**Why is this change necessary?**
Filtered developments on page load were being cleared by an unnecessary set call.

**How does it address the issue?**
This PR removes the unnecessary call and confirms that the call did not actually solve the problem that it was meant to solve. It was originally added in #161 to resolve #152 but it appears we can delete developments off the map without this line now.
