### PR TITLE
Reload selector more carefully when map style changes

### DIFF
--- a/ember/app/components/mapbox-map.js
+++ b/ember/app/components/mapbox-map.js
@@ -52,10 +52,6 @@ export default class extends Component {
       minZoom: 6,
     });
     this.mapboxglMap.on('load', () => {
-
-      this.mapboxglMap.on('styledata', () => {
-        this.draw(mapService);
-      });
       this.mapboxglMap.on('zoom', (e) => {
         // If a user attempts to abort a zoom, stop the animation.
         if (e.originalEvent) {
@@ -67,6 +63,9 @@ export default class extends Component {
       mapService.addObserver('viewing', this, 'draw');
       mapService.addObserver('filteredData', this, 'focus');
       mapService.addObserver('baseMap', this, 'setStyle');
+      this.mapboxglMap.on('style.load', () => {
+        this.selectionModeChangeHandler(mapService);
+      });
       mapService.addObserver('zoomCommand', this, 'actOnZoomCommand');
       mapService.addObserver('viewing', this, 'jumpTo');
       mapService.addObserver('selectionMode', this, 'selectionModeChangeHandler');
@@ -109,6 +108,8 @@ export default class extends Component {
   selectionModeChangeHandler(mapService) {
     this.draw(mapService);
     this.drawSelector(mapService);
+    this.set('previousCoordinatesKey', null);
+    this.set('previousParcel', null);
     this.updateSelection(true);
   }
 

--- a/ember/app/components/mapbox-map.js
+++ b/ember/app/components/mapbox-map.js
@@ -63,9 +63,6 @@ export default class extends Component {
       mapService.addObserver('viewing', this, 'draw');
       mapService.addObserver('filteredData', this, 'focus');
       mapService.addObserver('baseMap', this, 'setStyle');
-      this.mapboxglMap.on('style.load', () => {
-        this.selectionModeChangeHandler(mapService);
-      });
       mapService.addObserver('zoomCommand', this, 'actOnZoomCommand');
       mapService.addObserver('viewing', this, 'jumpTo');
       mapService.addObserver('selectionMode', this, 'selectionModeChangeHandler');
@@ -245,6 +242,11 @@ export default class extends Component {
 
   setStyle(mapService) {
     const newBaseMap = mapService.get('baseMap');
+    const redrawOnStyleReload = () => {
+      this.selectionModeChangeHandler(mapService);
+      this.mapboxglMap.off('styledata', redrawOnStyleReload);
+    };
+    this.mapboxglMap.on('styledata', redrawOnStyleReload);
     if (newBaseMap == 'light') {
       this.mapboxglMap.setStyle('mapbox://styles/mapbox/light-v9');
     } else if (newBaseMap == 'satellite') {


### PR DESCRIPTION
Resolves #192.

**Why is this change necessary?**
Switching the map style during editing or creation dropped the orange selector from the map.

**How does it address the issue?**
The selector and its location is redrawn when a style change occurs, and debouncing variables are cleared.