### PR TITLE
Solve validation confusion by making more fields generally required

### DIFF
--- a/ember/app/components/development-form.js
+++ b/ember/app/components/development-form.js
@@ -54,23 +54,36 @@ export default class extends Component {
       'hu',
       'commsf',
       'descr',
-    ];
-
-    const proposed = [
-      ...base,
-      'singfamhu', 'smmultifam', 'lgmultifam',
+      'singfamhu',
+      'smmultifam',
+      'lgmultifam',
+      'unknownhu',
+      'retSqft',
+      'ofcmdSqft',
+      'indmfSqft',
+      'whsSqft',
+      'rndSqft',
+      'eiSqft',
+      'otherSqft',
+      'hotelSqft',
+      'unkSqft',
     ];
 
     const groundBroken = [
-      ...proposed,
-      'affrdUnit', 'affU30', 'aff3050', 'aff5080', 'aff80p', 'gqpop', 'retSqft',
-      'ofcmdSqft', 'indmfSqft', 'whsSqft', 'rndSqft', 'eiSqft',
-      'otherSqft', 'hotelSqft', 'hotelrms', 'publicsqft',
+      ...base,
+      'affrdUnit',
+      'affU30',
+      'aff3050',
+      'aff5080',
+      'aff80p',
+      'gqpop',
+      'hotelrms',
+      'publicsqft',
     ];
 
     this.lastEdit = Date.now();
 
-    this.criteria = { base, proposed, groundBroken };
+    this.criteria = { base, groundBroken };
 
     Ember.run.later(this, () => this.updateFieldRequirements(), 500);
     const lng = this.get('editing.longitude');
@@ -169,13 +182,6 @@ export default class extends Component {
     );
   }
 
-
-  @computed('editing.status')
-  get isProposed() {
-    return this.get('editing.status') === 'planning';
-  }
-
-
   sumProperties() {
     const properties = this.getProperties(...arguments);
 
@@ -246,9 +252,6 @@ export default class extends Component {
 
     if (this.get('isGroundBroken')) {
       criteria = this.get('criteria.groundBroken');
-    }
-    else if (this.get('isProposed')) {
-      criteria = this.get('criteria.proposed');
     }
     else {
       criteria = this.get('criteria.base');

--- a/ember/app/templates/components/development-form.hbs
+++ b/ember/app/templates/components/development-form.hbs
@@ -42,6 +42,7 @@
         {{input
           id="development_latitude"
           value=(to-fixed editing.latitude 6)
+          class=(if inValid.latitude 'invalid')
           placeholder="Latitude"
           readonly="readonly"
         }}
@@ -49,6 +50,7 @@
         {{input
           id="development_longitude"
           value=(to-fixed editing.longitude 6)
+          class=(if inValid.longitude 'invalid')
           placeholder="Longitude"
           readonly="readonly"
         }}
@@ -378,7 +380,9 @@
             </tr>
 
             <tr>
-              <td>{{defined-term key="UNKNOWN_HOUSING_UNITS"}}</td>
+              <td>
+                <label for="unknownhu">{{defined-term key="UNKNOWN_HOUSING_UNITS"}}</label>
+              </td>
               <td>
                 {{input
                   class=(if inValid.unknownhu 'invalid')
@@ -825,7 +829,9 @@
 
             <tr>
               <td>
-                {{defined-term key='UNKNOWN_AREA'}}
+                <label for="unkSqft">
+                  {{defined-term key='UNKNOWN_AREA'}}
+                </label>
               </td>
               <td>
                 {{input


### PR DESCRIPTION
Resolves #194.

**Why is this change necessary?**
Validations on derived properties like `hu` (housing units) and `commsf` (commercial area) can be confusing because those values are not attached to an input field that we can highlight. This is a proposed new experience that just highlights all of the fields that make up those derived properties. It's not ideal, but if we want to insist that they fill out a number for those properties we're going to have to be clear.

**How does it address the issue?**
This makes all `hu` and `commsf` fields required for all status types on the client side.
