### PR TITLE
Apply column name change for municipal to share link serializer

### DIFF
--- a/ember/app/components/share-buttons.js
+++ b/ember/app/components/share-buttons.js
@@ -28,7 +28,7 @@ export default class extends Component {
 
     copier.class = 'copy-area';
     copier.innerHTML = window.location.href
-                                      .split('&municipality[]=').join(',')
+                                      .split('&municipal[]=').join(',')
                                       .split('&devlper[]=').join(',')
                                       .split('&nhood[]=').join(',')
                                       .split('[]=').join('=')

--- a/ember/app/controllers/map.js
+++ b/ember/app/controllers/map.js
@@ -92,8 +92,6 @@ export default class extends Controller {
           ) {
             found = Ember.copy(filters[col]);
 
-            console.log(found, value);
-
             if (found.filter === 'metric') {
               if (found.type === 'number') {
                 const metricParts = value.split(';');
@@ -109,8 +107,6 @@ export default class extends Controller {
               if (col === 'municipal') {
                 value = value.map(capitalize);
               }
-
-              console.log(col, value);
 
               Ember.set(found, 'value', value);
             }

--- a/ember/app/controllers/map.js
+++ b/ember/app/controllers/map.js
@@ -3,6 +3,7 @@ import Controller from '@ember/controller';
 import { action, computed } from 'ember-decorators/object';
 import { service } from 'ember-decorators/service';
 import filters from 'massbuilds/utils/filters';
+import { capitalize } from 'massbuilds/helpers/capitalize';
 import { alias } from 'ember-decorators/object/computed';
 
 export default class extends Controller {
@@ -91,6 +92,8 @@ export default class extends Controller {
           ) {
             found = Ember.copy(filters[col]);
 
+            console.log(found, value);
+
             if (found.filter === 'metric') {
               if (found.type === 'number') {
                 const metricParts = value.split(';');
@@ -103,6 +106,12 @@ export default class extends Controller {
               }
             }
             else {
+              if (col === 'municipal') {
+                value = value.map(capitalize);
+              }
+
+              console.log(col, value);
+
               Ember.set(found, 'value', value);
             }
           }

--- a/ember/app/utils/filters.js
+++ b/ember/app/utils/filters.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { statusOptions } from 'massbuilds/utils/status-colors';
+import { capitalize } from 'massbuilds/helpers/capitalize';
 import Development from 'massbuilds/models/development';
 const { decamelize } = Ember.String;
 
@@ -251,6 +252,10 @@ const fromQueryParams = params => {
       newParams[key].value = parseInt(num);
     }
     else {
+      if (_key === 'municipal') {
+        value = value.map(capitalize);
+      }
+
       newParams[key].value = value;
     }
   });


### PR DESCRIPTION
Resolves #204 .

# Why is this change necessary?
The share link serializer was producing an unusable URL.

# How does it address the issue?
It fixes the issue by changing the column name that the serializer is looking for.