### PR TITLE
Replace spinning square with tumbling cube

### DIFF
--- a/ember/app/components/spinning-cube.js
+++ b/ember/app/components/spinning-cube.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+
+
+export default class extends Component {
+
+  constructor() {
+    super(...arguments);
+
+    this.classNames = ["component", "spinning-cube"];
+  }
+
+}

--- a/ember/app/styles/components/_all.scss
+++ b/ember/app/styles/components/_all.scss
@@ -13,4 +13,5 @@
 @import 'development-form';
 @import 'verified-mark';
 @import 'loading-spinner';
+@import 'spinning-cube';
 @import 'goto-bar';

--- a/ember/app/styles/components/spinning-cube.scss
+++ b/ember/app/styles/components/spinning-cube.scss
@@ -1,0 +1,65 @@
+.component.spinning-cube {
+  $_color-side2: #94CCBC;
+  $_color-tb: #132A41;
+  $_color-side1: #3E7E93;
+
+  $_size: 15px;
+  $_speed: 1.4s;
+
+  z-index: 1000;
+  left: -$_size;
+  top: -$_size;
+  display: inline-block;
+
+  .cube {
+    position: relative;
+
+    width: $_size;
+    margin: 0 auto;
+
+    animation: tumble $_speed infinite linear;
+    transform-origin: ($_size / 2) ($_size / 2);
+    transform-style: preserve-3d;
+
+    div {
+      position: absolute;
+
+      width: $_size;
+      height: $_size;
+
+      &[data-side="back"] {
+        background: $_color-side1;
+        transform: translateZ(-#{$_size / 2}) rotateY(180deg);
+      }
+      &[data-side="front"] {
+        background: $_color-side1;
+        transform: translateZ(#{$_size / 2});
+      }
+
+      &[data-side="right"] {
+        background: $_color-side2;
+        transform: rotateY(-270deg) translateX(#{$_size / 2});
+        transform-origin: top right;
+      }
+      &[data-side="left"] {
+        background: $_color-side2;
+        transform: rotateY(270deg) translateX(-#{$_size / 2});
+        transform-origin: center left;
+      }
+
+      &[data-side="top"] {
+        background: $_color-tb;
+        transform: rotateX(-90deg) translateY(-#{$_size / 2});
+        transform-origin: top center;
+      }
+      &[data-side="bottom"] {
+        background: $_color-tb;
+        transform: rotateX(90deg) translateY(#{$_size / 2});
+        transform-origin: bottom center;
+      }
+
+
+    }
+  }
+
+}

--- a/ember/app/styles/partials/_animations.scss
+++ b/ember/app/styles/partials/_animations.scss
@@ -2,3 +2,8 @@
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+@keyframes tumble {
+  0% { transform: rotateX(0) rotateY(0); }
+  100% { transform: rotateX(-360deg) rotateY(360deg); }
+}

--- a/ember/app/templates/application-loading.hbs
+++ b/ember/app/templates/application-loading.hbs
@@ -4,9 +4,10 @@
     <h1>MassBuilds</h1>
 
     <div class="loader">
-      <span class="spinning-box"></span>
+      {{spinning-cube}}
+
       Loading User Profile
     </div>
   </div>
-  
+
 </section>

--- a/ember/app/templates/components/spinning-cube.hbs
+++ b/ember/app/templates/components/spinning-cube.hbs
@@ -1,0 +1,8 @@
+<div class="cube">
+  <div data-side="front"></div>
+  <div data-side="back"></div>
+  <div data-side="top"></div>
+  <div data-side="bottom"></div>
+  <div data-side="left"></div>
+  <div data-side="right"></div>
+</div>

--- a/ember/app/templates/map.hbs
+++ b/ember/app/templates/map.hbs
@@ -87,7 +87,7 @@
           <h1>MassBuilds</h1>
 
           <div class="loader">
-            <span class="spinning-box"></span>
+            {{spinning-cube}}
             Mapping Developments
           </div>
         </div>

--- a/ember/tests/integration/components/spinning-cube-test.js
+++ b/ember/tests/integration/components/spinning-cube-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('spinning-cube', 'Integration | Component | spinning cube', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{spinning-cube}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#spinning-cube}}
+      template block text
+    {{/spinning-cube}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
Resolves #nothing.

# Why is this change necessary?
Because cubes have a higher dimensionality than squares which means Massbuilds is now more advanced than ever.

# How does it address the issue?
![This PR resolves nothing](https://user-images.githubusercontent.com/6749126/42738776-8f8e771e-8857-11e8-8a34-00eaf40502c7.gif)


# What side effects does it have?
All spinning squares will evolve into tumbling cubes.