### PR TITLE
Allow a user to request verified status independent of a municipality

### DIFF
--- a/ember/app/components/signup-subpanel.js
+++ b/ember/app/components/signup-subpanel.js
@@ -27,7 +27,7 @@ export default class extends Component {
     this.munis = [];
     this.isFetching = false;
     this.muniFailure = false;
-    this.requestingMunicipal = false;
+    this.requesting = null;
   }
 
 
@@ -59,15 +59,15 @@ export default class extends Component {
   updateMunicipality(muni) {
     this.set('municipality', muni);
   }
- 
+
 
   @computed('fullName', 'username', 'password', 'confirmPassword')
   get submittable() {
     return [
-      'firstName', 
-      'lastName', 
+      'firstName',
+      'lastName',
       'username',
-      'password', 
+      'password',
       'confirmPassword'
     ].every(field => this.get(field) !== '');
   }
@@ -79,15 +79,15 @@ export default class extends Component {
       return;
     }
 
-    let noErrors = true; 
+    let noErrors = true;
     let errorMessage = 'You must fill in all fields.';
 
     const email = this.get('username');
     const { firstName, lastName } = this.getProperties('firstName', 'lastName');
     const { password, confirmPassword } = this.getProperties('password', 'confirmPassword');
-    const requestingMunicipal = this.get('requestingMunicipal');
-    const municipality = requestingMunicipal ? this.get('municipality') : null;
-    const requestVerifiedStatus = !!municipality;
+    const requesting = this.get('requesting');
+    const municipality = requesting == 'municipal' ? this.get('municipality') : null;
+    const requestVerifiedStatus = !!requesting;
 
 
     /**
@@ -95,19 +95,19 @@ export default class extends Component {
      */
 
     if (!email) {
-      noErrors = false; 
+      noErrors = false;
     }
 
     if (firstName && lastName) {
       const nameRegex = /^[A-Za-z\-']+$/;
 
       if ([firstName,lastName].any(name => !nameRegex.test(name))) {
-        noErrors = false; 
+        noErrors = false;
         errorMessage = 'Name may only contain letters.';
       }
     }
     else {
-      noErrors = false; 
+      noErrors = false;
 
       if (!lastName) {
         errorMessage = 'Must enter both a first and last name.';
@@ -116,12 +116,12 @@ export default class extends Component {
 
     if (password && confirmPassword) {
       if (password !== confirmPassword) {
-        noErrors = false; 
+        noErrors = false;
         errorMessage = 'Passwords do not match.';
       }
     }
     else {
-      noErrors = false; 
+      noErrors = false;
     }
 
 

--- a/ember/app/components/signup-subpanel.js
+++ b/ember/app/components/signup-subpanel.js
@@ -86,7 +86,9 @@ export default class extends Component {
     const { firstName, lastName } = this.getProperties('firstName', 'lastName');
     const { password, confirmPassword } = this.getProperties('password', 'confirmPassword');
     const requesting = this.get('requesting');
-    const municipality = requesting == 'municipal' ? this.get('municipality') : null;
+    const municipality = requesting == 'municipal'
+        ? this.get('municipality')
+        : (requesting == 'state' ? 'STATE' : null);
     const requestVerifiedStatus = !!requesting;
 
 

--- a/ember/app/controllers/map/users/verify.js
+++ b/ember/app/controllers/map/users/verify.js
@@ -36,8 +36,11 @@ export default class extends Controller {
   @action
   approveUser(user) {
     const { municipality, fullName } = user.getProperties('municipality', 'fullName');
-
-    user.set('role', 'municipal');
+    if (municipality) {
+      user.set('role', 'municipal');
+    } else {
+      user.set('role', 'verified');
+    }
     user.set('requestVerifiedStatus', false);
     user.save()
         .then(() => {

--- a/ember/app/controllers/map/users/verify.js
+++ b/ember/app/controllers/map/users/verify.js
@@ -22,13 +22,21 @@ export default class extends Controller {
     user.set('requestVerifiedStatus', false);
     user.save()
         .then(() => {
-          this.get('notifications').show(`You have denied ${municipality} membership to ${fullName}.`);
+          if (municipality == 'STATE') {
+            this.get('notifications').show(`You have denied verified status to ${fullName}.`);
+          } else {
+            this.get('notifications').show(`You have denied ${municipality} membership to ${fullName}.`);
+          }
+
           this.get('verifiableUsers').decrementCount();
         })
         .catch(() => {
           user.set('requestVerifiedStatus', true);
-
-          this.get('notifications').show(`An error occurred when denying ${municipality} membership to ${fullName}.`, { mode: 'error' });
+          if (municipality == 'STATE') {
+            this.get('notifications').show(`An error occurred when denying verified status to ${fullName}.`, { mode: 'error' });
+          } else {
+            this.get('notifications').show(`An error occurred when denying ${municipality} membership to ${fullName}.`, { mode: 'error' });
+          }
         });
   }
 
@@ -36,7 +44,7 @@ export default class extends Controller {
   @action
   approveUser(user) {
     const { municipality, fullName } = user.getProperties('municipality', 'fullName');
-    if (municipality) {
+    if (municipality && municipality != 'STATE') {
       user.set('role', 'municipal');
     } else {
       user.set('role', 'verified');
@@ -44,14 +52,22 @@ export default class extends Controller {
     user.set('requestVerifiedStatus', false);
     user.save()
         .then(() => {
-          this.get('notifications').show(`You have approved ${municipality} membership to ${fullName}.`);
+          if (municipality == 'STATE') {
+            this.get('notifications').show(`You have approved verified status for ${fullName}.`);
+          } else {
+            this.get('notifications').show(`You have approved ${municipality} membership to ${fullName}.`);
+          }
           this.get('verifiableUsers').decrementCount();
         })
         .catch(() => {
           user.set('role', 'user');
           user.set('requestVerifiedStatus', true);
+          if (municipality == 'STATE') {
+            this.get('notifications').show(`An error occurred when approving verified status for ${fullName}.`, { mode: 'error' });
+          } else {
+            this.get('notifications').show(`An error occurred when approving ${municipality} membership to ${fullName}.`, { mode: 'error' });
+          }
 
-          this.get('notifications').show(`An error occurred when approving ${municipality} membership to ${fullName}.`, { mode: 'error' });
         });
   }
 

--- a/ember/app/styles/components/notifications-popup.scss
+++ b/ember/app/styles/components/notifications-popup.scss
@@ -2,7 +2,7 @@
   $width: 300px;
 
   position: fixed;
-  bottom: -15px;
+  bottom: 0px;
   right: $width / 2;
   z-index: 999;
 
@@ -15,20 +15,20 @@
 
     color: $color_brand-primary;
     font-size: 14px;
-    
+
     background: $color_bg-light;
     border-radius: 5px;
     border: 1px solid $color_brand-primary--active;
     opacity: 0;
     transition: top .2s, opacity .2s;
 
-    &.error { 
+    &.error {
       color: $color_state-negative--dark;
-      border-color: $color_state-negative; 
+      border-color: $color_state-negative;
     }
 
     &.active {
-      top: -30px; 
+      top: -26px;
 
       opacity: 1;
       transition: top .2s, opacity .2s;

--- a/ember/app/styles/components/user-subpanels.scss
+++ b/ember/app/styles/components/user-subpanels.scss
@@ -5,11 +5,20 @@
     padding-top: 100px;
 
     text-align: center;
-
+    &.signup-subpanel {
+      padding-top: 65px;
+    }
     .logo-image {
       width: 40%;
       height: auto;
       margin: 0 auto;
+      &.sign-up {
+        width: 40px;
+        margin: 0;
+        position: absolute;
+        left: 25px;
+        top: 20px;
+      }
     }
 
     form {

--- a/ember/app/styles/components/user-subpanels.scss
+++ b/ember/app/styles/components/user-subpanels.scss
@@ -39,6 +39,10 @@
 
         background: $color_bg-light--accent;
 
+        label {
+          display: block;
+
+        }
         .loading-spinner {
           float: none;
 
@@ -48,14 +52,18 @@
         }
       }
 
-      label {
+      label, span {
         color: $color_font-medium;
         font-size: 11px;
+        margin-bottom: 0.2em;
       }
     }
 
     input {
-      &:not([type="checkbox"]) { width: 100%; }
+      &:not([type="checkbox"]):not([type="radio"]) { width: 100%; }
+      &[type="radio"] {
+        margin-right: 0.5em;
+      }
 
       margin: 5px auto;
       padding: 8px 16px;

--- a/ember/app/styles/routes/map.scss
+++ b/ember/app/styles/routes/map.scss
@@ -177,8 +177,8 @@
     }
 
     &.active {
-      top: 36px;
-      right: 30px;
+      top: 41px;
+      right: 40px;
     }
 
     .hamburger { @extend ._vertical-center; }

--- a/ember/app/templates/components/account-subpanel.hbs
+++ b/ember/app/templates/components/account-subpanel.hbs
@@ -12,16 +12,25 @@
     </h3>
 
     {{#unless verified}}
-      {{#if currentUser.user.municipality}}
-        {{#if currentUser.user.requestVerifiedStatus}}
+      {{#if currentUser.user.requestVerifiedStatus}}
+        {{currentUser.user.municipality}}
+        {{#if currentUser.user.municipality}}
           <h4 class="tag">Reviewing request for {{currentUser.user.municipality}} membership</h4>
         {{else}}
-          {{#unless removedDenialMessage}}
+          <h4 class="tag">Reviewing request for verified status</h4>
+        {{/if}}
+      {{else}}
+        {{#unless removedDenialMessage}}
+          {{#if currentUser.user.municipality}}
             <h4 class="tag inactive">
               Request for {{currentUser.user.municipality}} membership denied <span onclick={{action removeDenialMessage}}>X</span>
             </h4>
-          {{/unless}}
-        {{/if}}
+          {{else}}
+            <h4 class="tag inactive">
+              Request for verified status denied <span onclick={{action removeDenialMessage}}>X</span>
+            </h4>
+          {{/if}}
+        {{/unless}}
       {{/if}}
     {{else}}
       {{#if (eq currentUser.user.role 'municipal')}}
@@ -31,26 +40,26 @@
   </div>
 
   <div class="user-actions">
-    {{#link-to 'map.developments.create' click=(action closeMenu)}} 
+    {{#link-to 'map.developments.create' click=(action closeMenu)}}
       <div class="icon-wrapper">
-        <img src="/assets/images/plus.svg"> 
+        <img src="/assets/images/plus.svg">
       </div>
 
       Create Development
     {{/link-to}}
 
-    {{#link-to 'map.developments.for.user' currentUser.user.id click=(action closeMenu)}} 
+    {{#link-to 'map.developments.for.user' currentUser.user.id click=(action closeMenu)}}
       <div class="icon-wrapper">
-        <img src="/assets/images/map-pin.svg"> 
+        <img src="/assets/images/map-pin.svg">
       </div>
 
       My Developments
     {{/link-to}}
 
     {{#unless (eq currentUser.user.role 'admin')}}
-      {{#link-to 'map.moderations.for.user' currentUser.user.id click=(action closeMenu)}} 
+      {{#link-to 'map.moderations.for.user' currentUser.user.id click=(action closeMenu)}}
         <div class="icon-wrapper">
-          <img src="/assets/images/edit-3.svg"> 
+          <img src="/assets/images/edit-3.svg">
         </div>
 
         My Edits
@@ -58,17 +67,17 @@
     {{/unless}}
 
     {{#if (eq currentUser.user.role 'admin')}}
-      {{#link-to 'map.moderations.index' click=(action closeMenu)}} 
+      {{#link-to 'map.moderations.index' click=(action closeMenu)}}
         <div class="icon-wrapper">
-          <img src="/assets/images/edit-3.svg"> 
+          <img src="/assets/images/edit-3.svg">
         </div>
 
         Moderations
       {{/link-to}}
 
-      {{#link-to 'map.users.index' click=(action closeMenu)}} 
+      {{#link-to 'map.users.index' click=(action closeMenu)}}
         <div class="icon-wrapper">
-          <img src="/assets/images/user.svg"> 
+          <img src="/assets/images/user.svg">
         </div>
 
         Manage Users
@@ -86,7 +95,7 @@
       {{/if}}
     {{/if}}
   </div>
-  
+
 </div>
 
 <button class="logout-button" onclick={{action logout}}>

--- a/ember/app/templates/components/account-subpanel.hbs
+++ b/ember/app/templates/components/account-subpanel.hbs
@@ -12,25 +12,26 @@
     </h3>
 
     {{#unless verified}}
-      {{#if currentUser.user.requestVerifiedStatus}}
-        {{currentUser.user.municipality}}
-        {{#if currentUser.user.municipality}}
-          <h4 class="tag">Reviewing request for {{currentUser.user.municipality}} membership</h4>
-        {{else}}
-          <h4 class="tag">Reviewing request for verified status</h4>
-        {{/if}}
-      {{else}}
-        {{#unless removedDenialMessage}}
-          {{#if currentUser.user.municipality}}
-            <h4 class="tag inactive">
-              Request for {{currentUser.user.municipality}} membership denied <span onclick={{action removeDenialMessage}}>X</span>
-            </h4>
+      {{#if currentUser.user.municipality}}
+        {{#if currentUser.user.requestVerifiedStatus}}
+          {{#if (eq currentUser.user.municipality 'STATE')}}
+            <h4 class="tag">Reviewing request for verified status</h4>
           {{else}}
-            <h4 class="tag inactive">
-              Request for verified status denied <span onclick={{action removeDenialMessage}}>X</span>
-            </h4>
+            <h4 class="tag">Reviewing request for {{currentUser.user.municipality}} membership</h4>
           {{/if}}
-        {{/unless}}
+        {{else}}
+          {{#unless removedDenialMessage}}
+            {{#if (eq currentUser.user.municipality 'STATE')}}
+              <h4 class="tag inactive">
+                Request for verified status denied <span onclick={{action removeDenialMessage}}>X</span>
+              </h4>
+            {{else}}
+              <h4 class="tag inactive">
+                Request for {{currentUser.user.municipality}} membership denied <span onclick={{action removeDenialMessage}}>X</span>
+              </h4>
+            {{/if}}
+          {{/unless}}
+        {{/if}}
       {{/if}}
     {{else}}
       {{#if (eq currentUser.user.role 'municipal')}}

--- a/ember/app/templates/components/signup-subpanel.hbs
+++ b/ember/app/templates/components/signup-subpanel.hbs
@@ -1,5 +1,4 @@
-<img src="/assets/images/logo-with-text.png" class="logo-image">
-
+<img src="/assets/images/logo.png" class="logo-image sign-up">
 <form {{action signup on="submit"}}>
 
   <h2>Signup</h2>
@@ -93,3 +92,4 @@
   Already have an account?
   {{link-to 'Login here' (query-params panel=null)}}
 </div>
+

--- a/ember/app/templates/components/signup-subpanel.hbs
+++ b/ember/app/templates/components/signup-subpanel.hbs
@@ -35,14 +35,34 @@
 
   {{#unless muniFailure}}
     <div class="input-wrapper labeled">
-      <label>Are you a member of city/town, state, or regional government?</label>
-      {{input type="checkbox" checked=requestingMunicipal click=(action fetchMunis)}}
+      <span>Would you like to request verified status?</span>
+      {{#radio-button
+        value=""
+        groupValue=requesting
+      }}
+        <span>No</span>
+      {{/radio-button}}
+
+      {{#radio-button
+        value="state"
+        groupValue=requesting
+      }}
+        <span>Yes, as a member state or regional government</span>
+      {{/radio-button}}
+
+      {{#radio-button
+        value="municipal"
+        groupValue=requesting
+        changed=(action fetchMunis)
+      }}
+        <span>Yes, as a member of city or town government</span>
+      {{/radio-button}}
     </div>
 
-    {{#if requestingMunicipal}}
+    {{#if (eq requesting 'municipal')}}
       <div class="input-wrapper labeled">
         <label>Choose the municipality you are associated with</label>
-        
+
         {{#loading-spinner message="Loading Municipalities" isLoading=isFetching}}
           <select onchange={{action updateMunicipality value="target.value"}}>
             <option disabled selected>Select Municipality</option>
@@ -70,6 +90,6 @@
 </form>
 
 <div class="auth-switch">
-  Already have an account? 
+  Already have an account?
   {{link-to 'Login here' (query-params panel=null)}}
 </div>

--- a/ember/app/templates/map/users/verify.hbs
+++ b/ember/app/templates/map/users/verify.hbs
@@ -29,7 +29,7 @@
           <li>
             <div>{{user.fullName}}</div>
             <div>{{user.email}}</div>
-            <div>{{user.municipality}}</div>
+            <div>{{if (eq user.municipality 'STATE') 'State/Regional' user.municipality}}</div>
             <div><button class="styled negative" onclick={{action denyUser user}}>Deny</button></div>
             <div><button class="styled" onclick={{action approveUser user}}>Approve</button></div>
           </li>

--- a/ember/package-lock.json
+++ b/ember/package-lock.json
@@ -427,7 +427,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
       "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
-      "dev": true,
       "requires": {
         "ensure-posix-path": "1.0.2"
       }
@@ -447,14 +446,12 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "ansicolors": {
       "version": "0.2.1",
@@ -563,8 +560,7 @@
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-filter": {
       "version": "0.0.1",
@@ -709,7 +705,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -718,7 +713,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
       "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "heimdalljs": "0.2.5",
@@ -745,7 +739,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
       "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
-      "dev": true,
       "requires": {
         "async": "2.6.0",
         "debug": "2.6.9"
@@ -773,7 +766,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -784,7 +776,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.0",
@@ -831,7 +822,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-      "dev": true,
       "requires": {
         "babel-messages": "6.23.0",
         "babel-runtime": "6.26.0",
@@ -846,8 +836,7 @@
         "jsesc": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         }
       }
     },
@@ -855,7 +844,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -866,7 +854,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -878,7 +865,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -890,7 +876,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -901,7 +886,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -914,7 +898,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -924,7 +907,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -934,7 +916,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -944,7 +925,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -955,7 +935,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -968,7 +947,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
       "requires": {
         "babel-helper-optimise-call-expression": "6.24.1",
         "babel-messages": "6.23.0",
@@ -982,7 +960,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -992,7 +969,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1001,7 +977,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1022,7 +997,6 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
       "integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==",
-      "dev": true,
       "requires": {
         "semver": "5.4.1"
       }
@@ -1031,7 +1005,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.2.1.tgz",
       "integrity": "sha1-5j+QzDxxzGs7aftRtPYDEtbPc0w=",
-      "dev": true,
       "requires": {
         "ember-rfc176-data": "0.3.1"
       }
@@ -1134,8 +1107,7 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
@@ -1152,8 +1124,7 @@
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -1164,14 +1135,12 @@
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -1205,7 +1174,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1214,7 +1182,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1223,7 +1190,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0",
@@ -1236,7 +1202,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
       "requires": {
         "babel-helper-define-map": "6.26.0",
         "babel-helper-function-name": "6.24.1",
@@ -1253,7 +1218,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -1263,7 +1227,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1272,7 +1235,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -1282,7 +1244,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1291,7 +1252,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -1302,7 +1262,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1311,7 +1270,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -1322,7 +1280,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -1334,7 +1291,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -1345,7 +1301,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -1356,7 +1311,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
       "requires": {
         "babel-helper-replace-supers": "6.24.1",
         "babel-runtime": "6.26.0"
@@ -1366,7 +1320,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
       "requires": {
         "babel-helper-call-delegate": "6.24.1",
         "babel-helper-get-function-arity": "6.24.1",
@@ -1380,7 +1333,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -1390,7 +1342,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1399,7 +1350,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -1410,7 +1360,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1419,7 +1368,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1428,7 +1376,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -1439,7 +1386,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -1460,7 +1406,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
       "requires": {
         "regenerator-transform": "0.10.1"
       }
@@ -1469,7 +1414,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -1511,7 +1455,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -1549,7 +1492,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -1573,7 +1515,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -1586,7 +1527,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
@@ -1603,7 +1543,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
@@ -1626,8 +1565,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "backbone": {
       "version": "1.3.3",
@@ -1647,8 +1585,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base-64": {
       "version": "0.1.0",
@@ -1711,14 +1648,12 @@
     "binaryextensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.0.0.tgz",
-      "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8=",
-      "dev": true
+      "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8="
     },
     "blank-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
-      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk=",
-      "dev": true
+      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk="
     },
     "blob": {
       "version": "0.0.4",
@@ -1827,7 +1762,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1887,7 +1821,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
       "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
-      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "broccoli-funnel": "1.2.0",
@@ -2022,7 +1955,6 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
       "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
-      "dev": true,
       "requires": {
         "broccoli-plugin": "1.3.0",
         "fs-tree-diff": "0.5.7",
@@ -2085,7 +2017,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
       "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-      "dev": true,
       "requires": {
         "array-equal": "1.0.0",
         "blank-object": "1.0.2",
@@ -2113,7 +2044,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
       "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
-      "dev": true,
       "requires": {
         "glob": "5.0.15",
         "mkdirp": "0.5.1"
@@ -2138,7 +2068,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
       "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-      "dev": true,
       "requires": {
         "broccoli-plugin": "1.3.0",
         "can-symlink": "1.0.0",
@@ -2164,7 +2093,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
       "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
-      "dev": true,
       "requires": {
         "async-disk-cache": "1.3.3",
         "async-promise-queue": "1.0.4",
@@ -2185,7 +2113,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
-      "dev": true,
       "requires": {
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
@@ -2276,8 +2203,7 @@
     "broccoli-source": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
-      "dev": true
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
     },
     "broccoli-sri-hash": {
       "version": "2.1.2",
@@ -2767,7 +2693,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
       "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000780",
         "electron-to-chromium": "1.3.28"
@@ -2884,7 +2809,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
       "integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=",
-      "dev": true,
       "requires": {
         "tmp": "0.0.28"
       }
@@ -2892,8 +2816,7 @@
     "caniuse-lite": {
       "version": "1.0.30000780",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000780.tgz",
-      "integrity": "sha1-H5CV8u/UlA4LpsWZKreptkzDW6Q=",
-      "dev": true
+      "integrity": "sha1-H5CV8u/UlA4LpsWZKreptkzDW6Q="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -2934,7 +2857,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
@@ -3141,8 +3063,7 @@
     "clone": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-      "dev": true
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
     },
     "co": {
       "version": "4.6.0",
@@ -3286,8 +3207,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -3650,7 +3570,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -3894,7 +3813,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -4006,8 +3924,7 @@
     "editions": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls=",
-      "dev": true
+      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -4018,8 +3935,7 @@
     "electron-to-chromium": {
       "version": "1.3.28",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
-      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
-      "dev": true
+      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -4302,7 +4218,6 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.10.0.tgz",
       "integrity": "sha512-MbgXmePweFzjkpN0l2eYFIU6XKfEKCaAx4Xk9wdL3vsPAvAm4N0DXnz4pOQ3OLezhl0bJJvutD3uLQ7Eo3sSTA==",
-      "dev": true,
       "requires": {
         "amd-name-resolver": "0.0.7",
         "babel-plugin-debug-macros": "0.1.11",
@@ -5039,7 +4954,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
       "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
-      "dev": true,
       "requires": {
         "resolve": "1.5.0",
         "semver": "5.4.1"
@@ -5602,6 +5516,45 @@
         }
       }
     },
+    "ember-radio-button": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ember-radio-button/-/ember-radio-button-1.2.4.tgz",
+      "integrity": "sha1-fKGsA/eQNpVNvuspJjUJZe5NtJc=",
+      "requires": {
+        "ember-cli-babel": "6.10.0",
+        "ember-cli-htmlbars": "1.3.4"
+      },
+      "dependencies": {
+        "ember-cli-htmlbars": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz",
+          "integrity": "sha512-5lycG6z35QHr3WZF1OkVvT+N/GGAVuemtM6m8NUgBWoeA2TqOgPFRcI0eRqoLA0HAfe0R2MReKmMI7y1LEM1+w==",
+          "requires": {
+            "broccoli-persistent-filter": "1.4.3",
+            "ember-cli-version-checker": "1.3.1",
+            "hash-for-dep": "1.2.3",
+            "json-stable-stringify": "1.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "requires": {
+            "semver": "5.4.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
+    },
     "ember-resolver": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-4.5.0.tgz",
@@ -5632,8 +5585,7 @@
     "ember-rfc176-data": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz",
-      "integrity": "sha512-u+W5rUvYO7xyKJjiPuCM7bIAvFyPwPTJ66fOZz1xuCv3AyReI9Oev5oOADOO6YJZk+vEn0xWiZ9N6zSf8WU7Fg==",
-      "dev": true
+      "integrity": "sha512-u+W5rUvYO7xyKJjiPuCM7bIAvFyPwPTJ66fOZz1xuCv3AyReI9Oev5oOADOO6YJZk+vEn0xWiZ9N6zSf8WU7Fg=="
     },
     "ember-router-generator": {
       "version": "1.2.3",
@@ -6673,8 +6625,7 @@
     "ensure-posix-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
-      "dev": true
+      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI="
     },
     "entities": {
       "version": "1.1.1",
@@ -6780,8 +6731,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.1",
@@ -7148,8 +7098,7 @@
     "exists-sync": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
-      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
-      "dev": true
+      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk="
     },
     "exit": {
       "version": "0.1.2",
@@ -7323,7 +7272,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
       "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
-      "dev": true,
       "requires": {
         "blank-object": "1.0.2"
       }
@@ -7660,7 +7608,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
       "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
-      "dev": true,
       "requires": {
         "heimdalljs-logger": "0.1.9",
         "object-assign": "4.1.1",
@@ -7671,8 +7618,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.3",
@@ -8862,7 +8808,6 @@
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
       "requires": {
         "inflight": "1.0.6",
         "inherits": "2.0.3",
@@ -8915,8 +8860,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "5.0.0",
@@ -9150,7 +9094,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -9203,7 +9146,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
       "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
-      "dev": true,
       "requires": {
         "broccoli-kitchen-sink-helpers": "0.3.1",
         "heimdalljs": "0.2.5",
@@ -9237,7 +9179,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
       "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
-      "dev": true,
       "requires": {
         "rsvp": "3.2.1"
       },
@@ -9245,8 +9186,7 @@
         "rsvp": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-          "dev": true
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
         }
       }
     },
@@ -9270,7 +9210,6 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
       "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "heimdalljs": "0.2.5"
@@ -9297,7 +9236,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -9437,7 +9375,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -9553,7 +9490,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -9630,7 +9566,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -9773,8 +9708,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "0.2.0",
@@ -9818,7 +9752,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
-      "dev": true,
       "requires": {
         "binaryextensions": "2.0.0",
         "editions": "1.3.3",
@@ -9846,8 +9779,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.10.0",
@@ -9875,8 +9807,7 @@
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-      "dev": true
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -9894,7 +9825,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -9920,8 +9850,7 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "2.4.0",
@@ -9935,8 +9864,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -10126,8 +10054,7 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -10632,7 +10559,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -10763,7 +10689,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
       "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
-      "dev": true,
       "requires": {
         "minimatch": "3.0.4"
       }
@@ -10966,7 +10891,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -10980,7 +10904,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -10988,8 +10911,7 @@
     "mktemp": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
-      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
-      "dev": true
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
     },
     "module-deps": {
       "version": "4.1.1",
@@ -11114,8 +11036,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mustache": {
       "version": "2.3.0",
@@ -11353,8 +11274,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -11365,8 +11285,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
@@ -11413,7 +11332,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -11511,8 +11429,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "1.4.0",
@@ -11532,8 +11449,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.4",
@@ -11680,8 +11596,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -11709,8 +11624,7 @@
     "path-posix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
-      "dev": true
+      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -11830,8 +11744,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.11.10",
@@ -11863,7 +11776,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
-      "dev": true,
       "requires": {
         "rsvp": "3.6.2"
       }
@@ -11936,7 +11848,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
-      "dev": true,
       "requires": {
         "mktemp": "0.4.0",
         "rimraf": "2.6.2",
@@ -12273,8 +12184,7 @@
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-      "dev": true
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
     },
     "regenerator": {
       "version": "0.8.40",
@@ -12325,7 +12235,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -12392,7 +12301,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
       "requires": {
         "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
@@ -12402,14 +12310,12 @@
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
       "requires": {
         "jsesc": "0.5.0"
       }
@@ -12436,7 +12342,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
@@ -12560,7 +12465,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       },
@@ -12569,7 +12473,6 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -12633,8 +12536,7 @@
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "rsyncwrapper": {
       "version": "0.4.2",
@@ -12779,8 +12681,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "send": {
       "version": "0.16.1",
@@ -13010,8 +12911,7 @@
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -13216,7 +13116,6 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
       "requires": {
         "source-map": "0.5.7"
       }
@@ -13319,8 +13218,7 @@
     "sprintf-js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
-      "dev": true
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
     },
     "sri-toolbox": {
       "version": "0.2.0",
@@ -13690,7 +13588,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -13770,14 +13667,12 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "symlink-or-copy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
-      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM=",
-      "dev": true
+      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM="
     },
     "syntax-error": {
       "version": "1.3.0",
@@ -13968,8 +13863,7 @@
     "textextensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.1.0.tgz",
-      "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M=",
-      "dev": true
+      "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M="
     },
     "through": {
       "version": "2.3.8",
@@ -14041,7 +13935,6 @@
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -14067,8 +13960,7 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -14083,7 +13975,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "fs-tree-diff": "0.5.7",
@@ -14096,7 +13987,6 @@
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-          "dev": true,
           "requires": {
             "ensure-posix-path": "1.0.2",
             "matcher-collection": "1.0.5"
@@ -14113,8 +14003,7 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "true-case-path": {
       "version": "1.0.2",
@@ -14269,7 +14158,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.1.1",
         "util-deprecate": "1.0.2"
@@ -14332,8 +14220,7 @@
     "username-sync": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.1.tgz",
-      "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8=",
-      "dev": true
+      "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8="
     },
     "util": {
       "version": "0.10.3",
@@ -14441,7 +14328,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
-      "dev": true,
       "requires": {
         "ensure-posix-path": "1.0.2",
         "matcher-collection": "1.0.5"
@@ -14551,7 +14437,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz",
       "integrity": "sha512-JP5DpviEV84zDmz13QnD4FfRjZBjnTOYY2O4pGgxtlqLh47WOzQFHm8o17TE5OSfcDoKC6vHSrN4yPju93DW0Q==",
-      "dev": true,
       "requires": {
         "object-assign": "4.1.1"
       }
@@ -14591,8 +14476,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/ember/package.json
+++ b/ember/package.json
@@ -60,9 +60,10 @@
     "node": "^4.5 || 6.* || >= 7.*"
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
     "@turf/boolean-point-in-polygon": "^6.0.1",
     "@turf/center-of-mass": "^6.0.1",
+    "babel-polyfill": "^6.26.0",
+    "ember-radio-button": "^1.2.4",
     "mapbox-gl": "^0.45.0"
   }
 }


### PR DESCRIPTION
Resolves #211 .

**Why is this change necessary?**
State and regional users will want the ability to request verified status independent of a specific municipality. Specifically, it's important that they can create developments outside of their home town.
