### PR TITLE
Fix incorrect regex use

### DIFF
--- a/rails/app/controllers/developments_controller.rb
+++ b/rails/app/controllers/developments_controller.rb
@@ -154,7 +154,7 @@ class DevelopmentsController < ApplicationController
             (['=', '<', '>'].include?(inflector)) &&
             (
              (type == 'string') ||
-             (type == 'number' && (/\A[-+]?\d+\z/ === value)) ||
+             (type == 'number' && (/\A[-+]?\d+\z/.match(value.to_s))) ||
              (type == 'boolean' && (value == 'true' || value == 'false'))
             )
           )


### PR DESCRIPTION
Resolves #237.

**Why is this change necessary?**
A regex was used incorrectly causing a failure of all numeric filters on download.

**How does it address the issue?**
We perform the regex properly.
