### PR TITLE
Resolve #242 Fix Action Mailer

### DIFF
--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
@@ -80,6 +80,7 @@ Rails.application.configure do
     api_key: Rails.application.secrets.mailgun_api_key,
     domain: 'mailgun2.mapc.org'
   }
+  config.action_mailer.default_url_options = { host: 'www.massbuilds.com' }
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
Resolves #242

# Why is this change necessary?
ActionMailer was not sending emails when we attempted to send password reset emails.

# How does it address the issue?
Setting the action_mailer default_url_options which allows ActionMailer to appropriately construct routes using route helpers in production.

# What side effects does it have?
Email templates will now use the www.massbuilds.com domain.