### PR TITLE
Fix validations for summed values equal to 0

### DIFF
--- a/ember/app/components/development-form.js
+++ b/ember/app/components/development-form.js
@@ -268,7 +268,9 @@ export default class extends Component {
 
   handleUpdate(fieldName, calculatedValue) {
     const modeled = this.get(`model.${fieldName}`);
-    let edited = calculatedValue || this.get(`editing.${fieldName}`);
+    let edited = calculatedValue == undefined
+        ? this.get(`editing.${fieldName}`)
+        : calculatedValue;
 
     // Adjust values if nonstandard
     if (fieldName === 'status') {
@@ -287,7 +289,6 @@ export default class extends Component {
     // Send updates to controller state
     this.sendAction('updateEditing', { [fieldName]: edited });
     this.set(`editing.${fieldName}`, edited);
-
     // If value changed, set proposedChanges
     if ((
       modeled === undefined


### PR DESCRIPTION
Resolves #248.

**Why is this change necessary?**
Edits for existing legacy developments with a null summed values (like `hu` or `commsf`) where the summed value was being explicitly changed to 0 would not be validated.

**How does it address the issue?**
Summed values equal to 0 were being interpreted by an OR statement as falsy and being overwritten with `null`, causing the validation on those summed values to fail.
