### PR TITLE
Geocode in municipal permissions policy for new developments

### DIFF
--- a/rails/app/models/development.rb
+++ b/rails/app/models/development.rb
@@ -108,7 +108,7 @@ class Development < ApplicationRecord
     if result && JSON.parse(result.body)['features'].length > 0
       properties = JSON.parse(result.body)['features'][0]['properties']
       self.update_columns(
-        municipal: properties['locality'],
+        municipal: (properties['locality'] || properties['localadmin']),
         address: properties['name'],
         zip_code: properties['postalcode']
       )

--- a/rails/app/policies/development_policy.rb
+++ b/rails/app/policies/development_policy.rb
@@ -8,7 +8,7 @@ class DevelopmentPolicy < ApplicationPolicy
   end
 
   def create?
-    !user&.disabled? && (user&.admin? || user&.verified? || (user&.municipal? && (record.municipal == user.municipality)))
+    !user&.disabled? && (user&.admin? || user&.verified? || (user&.municipal? && (record.municipal == user.municipality || get_municipality(record) == user.municipality)))
   end
 
   def update?
@@ -22,4 +22,15 @@ class DevelopmentPolicy < ApplicationPolicy
   def destroy?
     !user&.disabled? && (user&.admin? || (user&.municipal? && (record.municipal == user.municipality)))
   end
+
+  private
+
+  def get_municipality(record)
+    result = Faraday.get "https://pelias.mapc.org/v1/reverse?point.lat=#{record.latitude}&point.lon=#{record.longitude}"
+    if result && JSON.parse(result.body)['features'].length > 0
+      properties = JSON.parse(result.body)['features'][0]['properties']
+      return (properties['locality'] || properties['localadmin'])
+    end
+  end
+
 end


### PR DESCRIPTION
Resolves #252.

**Why is this change necessary?**
Municipal users cannot create developments because they development has not been geocoded before it hits the policy guarding the controller.

**How does it address the issue?**
This PR geocodes within the policy to ensure that municipal users can create developments within their town.
