### PR TITLE
Resolve #234 Update Font for Popups

### DIFF
--- a/ember/app/styles/components/mapbox-map.scss
+++ b/ember/app/styles/components/mapbox-map.scss
@@ -6,6 +6,7 @@
   bottom: 0;
   .mapboxgl-popup-content {
     padding: 0;
+    font-family: $font_family-primary;
   }
 
   .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,


### PR DESCRIPTION
The popup fonts were Arial but we wanted it to match the rest of the website. This commit adds the font-family attribute to the mapboxgl popup content class and we now have consistancy.
