### PR TITLE
Move Database Setup Tasks to Seeds

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -6,13 +6,6 @@ Before running `bin/setup` you need to set two environment variables: `FOREIGN_D
 
 You will need a mapquest api key set `MAPQUEST_API_KEY` in your .env for the geocoder to work.
 
-Before running the test suite you need to enable the foreign data wrapper in the test database:
-
-  RAILS_ENV=test rake db:add_foreign_data_wrapper_interface
-  RAILS_ENV=test rake db:add_rpa_fdw
-  RAILS_ENV=test rake db:add_counties_fdw
-  RAILS_ENV=test rake db:add_municipalities_fdw
-
 ### Postgres Security Challenges
 
 In order to implement foreign data wrappers your postgres user defined in `database.yml` needs to have super user privileges or it will fail. You can do this with: `ALTER ROLE massbuilds WITH SUPERUSER;`

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -6,3 +6,9 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 # sh "shp2pgsql -I -a -s 26986 #{Rails.root.join('lib', 'import', 'ma_municipalities.shp')} ma_municipalities | psql -d #{Rails.configuration.database_configuration[Rails.env]["database"]}"
+Rake::Task["db:add_foreign_data_wrapper_interface"].invoke
+Rake::Task["db:add_rpa_fdw"].invoke
+Rake::Task["db:add_counties_fdw"].invoke
+Rake::Task["db:add_municipalities_fdw"].invoke
+Rake::Task["db:add_tod_service_area_poly"].invoke
+Rake::Task["db:add_neighborhoods_poly"].invoke

--- a/rails/lib/tasks/db.rake
+++ b/rails/lib/tasks/db.rake
@@ -47,12 +47,3 @@ namespace :db do
     ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (tod_service_area_poly) FROM SERVER dblive95 INTO public;"
   end
 end
-
-Rake::Task["db:create"].enhance do
-  Rake::Task["db:add_foreign_data_wrapper_interface"].invoke
-  Rake::Task["db:add_rpa_fdw"].invoke
-  Rake::Task["db:add_counties_fdw"].invoke
-  Rake::Task["db:add_municipalities_fdw"].invoke
-  Rake::Task["db:add_tod_service_area_poly"].invoke
-  Rake::Task["db:add_neighborhoods_poly"].invoke
-end


### PR DESCRIPTION
Since we need our foreign data wrappers to be setup when we run our test suite and development databases, the correct home for it is in seeds.rb where they will be invoked on database creation in all environments. As a result of this improvement we can then remove some setup steps from our README.md.
