### PR TITLE
Resolve #281 Allow Closing Splash on iPhone

### DIFF
--- a/ember/app/templates/components/welcome-modal.hbs
+++ b/ember/app/templates/components/welcome-modal.hbs
@@ -6,17 +6,6 @@
   <p>
     Massbuilds is the Metropolitan Area Planning Council’s collaborative inventory of past, present and future real estate development projects. This tool provides governments, data analysts, urban planners, community advocates, and real estate developers with comprehensive data for thousands of projects across Massachusetts.
   </p>
-  <ul>
-    <li>
-      <b>Filter and find development projects:</b> Find the development data you need, filtering by neighborhood, municipality, construction status, affordable housing, units, square footage, project status, year of completion, developer name, and more!
-    </li>
-    <li>
-      <b>Contribute new data:</b> Sign up to add new and existing real estate developments in your area. Entries are all verified by MAPC’s data team to ensure accurate, up to date information.
-    </li>
-    <li>
-      <b>Export data:</b> Export comprehensive raw development data into a spreadsheet or shapefile for further analysis.
-    </li>
-  </ul>
   <div class="button-row">
     {{link-to 'Learn more' 'about'}}
     <button class="styled" onclick={{action 'dismissWelcome'}}>


### PR DESCRIPTION
Content, it’s fun. We write. We share. Unfortunately our ideas can be bigger than the divs we planned to contain them. Users then lose the ability to close a modal on their iPhones. They cannot see our site. Sad! This fix removes content, for now, to allow most users to access the site. When we have time and resources we can bring this back.
