### PR TITLE
Resolve #267 Moderation Overload

### DIFF
--- a/ember/app/routes/map/moderations/index.js
+++ b/ember/app/routes/map/moderations/index.js
@@ -18,7 +18,13 @@ export default Route.extend({
 
 
   model() {
-    return RSVP.resolve(this.get('store').findAll('edit')).then(edits => {
+    return RSVP.resolve(this.get('store')
+                            .query('edit', {
+                              filter: {
+                                approved: false
+                              }
+                            }))
+              .then(edits => {
       return RSVP.hash({
         edits,
         developments: RSVP.all(edits.map(edit => edit.belongsTo('development').reload())),

--- a/rails/app/controllers/edits_controller.rb
+++ b/rails/app/controllers/edits_controller.rb
@@ -4,8 +4,11 @@ class EditsController < ApplicationController
   # GET /edits
   def index
     authorize Edit
-    @edits = Edit.all
-
+    @edits = if params[:filter]
+               Edit.where(approved: params[:filter][:approved])
+             else
+               Edit.all
+             end
     respond_to do |format|
       format.jsonapi { render jsonapi: @edits }
     end
@@ -82,6 +85,8 @@ class EditsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def edit_params
+      # TODO: Figure out how to permit filter params when calling index.
+      # Typical rails approach: params.permit(filter: [:approved])
       respond_to do |format|
         format.jsonapi { ActiveModelSerializers::Deserialization.jsonapi_parse(params) }
       end

--- a/rails/spec/factories/edits.rb
+++ b/rails/spec/factories/edits.rb
@@ -24,5 +24,6 @@ FactoryBot.define do
         headqtrs: false,
         ovr55: false }
     end
+    approved false
   end
 end

--- a/rails/spec/requests/edits_spec.rb
+++ b/rails/spec/requests/edits_spec.rb
@@ -8,10 +8,32 @@ RSpec.describe "Edits", type: :request do
     hash.to_json
   }
 
+  let(:valid_filter_not_approved_params) do
+    { filter: { approved: false } }
+  end
+
+  let(:valid_filter_approved_params) do
+   { filter: { approved: true } }
+  end
+
   describe "listing all the edits" do
     it "works as an admin" do
       get edits_path, headers: admin_user_session
       expect(response).to have_http_status(:success)
+    end
+
+    it 'lets me filter by not approved' do
+      create(:edit)
+      get edits_path, params: valid_filter_not_approved_params, headers: admin_user_session
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)['data'].count).to eq(1)
+    end
+
+    it 'lets me filter by approved' do
+      create(:edit)
+      get edits_path, params: valid_filter_approved_params, headers: admin_user_session
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)['data'].count).to eq(0)
     end
 
     it "does not work as a user" do


### PR DESCRIPTION
* Instead of always querying all edits we add a parameter that only queries for unapproved edits. This greatly reduces the number of requests made to the server.
* Added note about properly using safe parameters with JSON API fitler param in a get request (which is allowed by the JSON API spec, but apparently not supported by ActiveModelSerializers).

Co-authored-by: Annabelle Thomas Taylor <ataylor@mapc.org>
