### PR TITLE
Mjz/309 fix permissions issue

### DIFF
--- a/rails/app/policies/development_policy.rb
+++ b/rails/app/policies/development_policy.rb
@@ -29,7 +29,7 @@ class DevelopmentPolicy < ApplicationPolicy
     result = Faraday.get "https://pelias.mapc.org/v1/reverse?point.lat=#{record.latitude}&point.lon=#{record.longitude}"
     if result && JSON.parse(result.body)['features'].length > 0
       properties = JSON.parse(result.body)['features'][0]['properties']
-      return (properties['locality'] || properties['localadmin'])
+      return (properties['locality'].upcase || properties['localadmin'].upcase)
     end
   end
 

--- a/rails/app/policies/development_policy.rb
+++ b/rails/app/policies/development_policy.rb
@@ -29,7 +29,7 @@ class DevelopmentPolicy < ApplicationPolicy
     result = Faraday.get "https://pelias.mapc.org/v1/reverse?point.lat=#{record.latitude}&point.lon=#{record.longitude}"
     if result && JSON.parse(result.body)['features'].length > 0
       properties = JSON.parse(result.body)['features'][0]['properties']
-      return (properties['locality'].upcase || properties['localadmin'].upcase)
+      return (properties['locality'] || properties['localadmin']).upcase
     end
   end
 

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -6,8 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 #
-scp massbuilds@prep.mapc.org:/home/massbuilds/massbuilds.dump tmp/massbuilds.dump
-pg_restore -a -d massbuilds_development -O -t users -t developments -t parcels -t edits tmp/massbuilds.dump
+# scp massbuilds@prep.mapc.org:/home/massbuilds/massbuilds.dump tmp/massbuilds.dump
+# pg_restore -a -d massbuilds_development -O -t users -t developments -t parcels -t edits tmp/massbuilds.dump
 
 Rake::Task["db:add_foreign_data_wrapper_interface"].invoke
 Rake::Task["db:add_rpa_fdw"].invoke

--- a/rails/lib/tasks/db.rake
+++ b/rails/lib/tasks/db.rake
@@ -22,6 +22,14 @@ namespace :db do
   task add_neighborhoods_poly: :environment do
     ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (neighborhoods_poly) FROM SERVER dblive95 INTO public;"
   end
+  
+  task delete_neighborhoods_poly: :environment do
+    ActiveRecord::Base.connection.execute "DROP FOREIGN TABLE IF EXISTS neighborhoods_poly;"
+  end
+  
+  task delete_tod_service_area_poly: :environment do
+    ActiveRecord::Base.connection.execute "DROP FOREIGN TABLE IF EXISTS tod_service_area_poly;"
+  end
 
   task delete_rpa_fdw: :environment do
     ActiveRecord::Base.connection.execute "DROP FOREIGN TABLE IF EXISTS rpa_poly"


### PR DESCRIPTION
Resolves #309.

# Why is this change necessary?
Municipal users were not able to add developments despite the fact they should be able to do so.

# How does it address the issue?
We update the strings from Pelias to be UPCASE before doing the comparison so it works going forward.

# What side effects does it have?
We also add fixes for previously undiscovered setup issues related to foreign data wrappers that were necessary to resolve this bug from a fresh setup of the develop branch.
