### PR TITLE
Resolve #316 Fix Delete Permissions

### DIFF
--- a/rails/app/policies/development_policy.rb
+++ b/rails/app/policies/development_policy.rb
@@ -16,7 +16,7 @@ class DevelopmentPolicy < ApplicationPolicy
   end
 
   def destroy?
-    !user&.disabled? && (user&.admin? || (user&.municipal? && (record.municipal == user.municipality)))
+    !user&.disabled? && (user&.admin? || (user&.municipal? && (record.municipal == user.municipality || get_municipality(record) == user.municipality)))
   end
 
   def flag?


### PR DESCRIPTION
* Because it is generally not the case that we are providing a record.municipal value when we submit data to the MassBuilds API, we need to use the get_municipality() function to get it. This has the destroy? method mirror the permissions for create? so municipal users can delete their entries.
