### PR TITLE
Mjz/308 mepa id traffic monitoring

### DIFF
--- a/ember/app/content.js
+++ b/ember/app/content.js
@@ -162,6 +162,14 @@ const content = {
       label: 'Parcel Fiscal Year',
       definition: ['Fiscal Year of the assessor\'s data from which the parcel\'s information was extracted.'],
     },
+    MEPAID: {
+      label: 'MEPA ID',
+      definition: ['five-digit integer corresponding to the "EEA No." in the MEPA Project Database at http://eeaonline.eea.state.ma.us/eea/emepa/searcharchive.aspx']
+    },
+    TRAFFIC_COUNT_DATA: {
+      label: 'Traffic Count URL',
+      definition: ['A URL linking to the MassDOT Transportation Impact Assessment Monitoring Report database or another source of data about traffic monitoring/traffic counts.']
+    },
   }, // End of Glossary
 
   OTHER_TERMS: {
@@ -233,7 +241,7 @@ const content = {
         'If the unit types are unknown, enter the number of housing units here.',
       ],
     },
-  },
+  }
 };
 
 content['TERMS'] = Object.assign({}, content.GLOSSARY, content.OTHER_TERMS);

--- a/ember/app/content.js
+++ b/ember/app/content.js
@@ -164,7 +164,7 @@ const content = {
     },
     MEPAID: {
       label: 'MEPA ID',
-      definition: ['five-digit integer corresponding to the "EEA No." in the MEPA Project Database at http://eeaonline.eea.state.ma.us/eea/emepa/searcharchive.aspx']
+      definition: ['Five-digit integer corresponding to the "EEA No." in the MEPA Project Database at http://eeaonline.eea.state.ma.us/eea/emepa/searcharchive.aspx']
     },
     TRAFFIC_COUNT_DATA: {
       label: 'Traffic Count URL',

--- a/ember/app/models/development.js
+++ b/ember/app/models/development.js
@@ -20,6 +20,7 @@ export default class extends DS.Model {
   @attr('string') parcelId;
   @attr('string') municipal;
   @attr('string') devlper;
+  @attr('string') trafficCountData;
 
   @attr('number') height;
   @attr('number') stories;
@@ -57,6 +58,7 @@ export default class extends DS.Model {
   @attr('number') aff80p;
   @attr('number') affUnknown;
   @attr('number') publicsqft;
+  @attr('number') mepaId;
 
   @attr('boolean', { default: false }) rdv;
   @attr('boolean', { default: false }) asofright;

--- a/ember/app/templates/components/development-form.hbs
+++ b/ember/app/templates/components/development-form.hbs
@@ -106,6 +106,22 @@
                   input=(action checkForUpdated 'descr')}}
               </p>
             </div>
+            <div class="field">
+              <label>{{defined-term key='MEPAID'}}</label>
+              {{input
+                value=editing.mepaId
+                class=(if inValid.mepaId 'invalid')
+                placeholder="Enter MEPA ID"
+                input=(action checkForUpdated 'mepaId')}}
+            </div>
+            <div class="field">
+              <label>{{defined-term key='TRAFFIC_COUNT_DATA'}}</label>
+              {{input
+                value=editing.trafficCountData
+                class=(if inValid.trafficCountData 'invalid')
+                placeholder="Enter URL for Traffic Count Data"
+                input=(action checkForUpdated 'trafficCountData')}}
+            </div>
           </div>
         </div>
       </article>

--- a/ember/app/templates/map/developments/development/index.hbs
+++ b/ember/app/templates/map/developments/development/index.hbs
@@ -62,6 +62,20 @@
                 <label for="description">{{defined-term key="DESCRIPTION"}}</label>
                 <p>{{model.descr}}</p>
               </div>
+              <div class="row">
+                <div class="column">
+                  <div class="field">
+                    <label for="mepaId">{{defined-term key="MEPAID"}}</label>
+                    {{model.mepaId}}
+                  </div>
+                </div>
+                <div class="column">
+                  <div class="field">
+                    <label for="trafficCountData">{{defined-term key="TRAFFIC_COUNT_DATA"}}</label>
+                    <a href="{{model.trafficCountData}}">{{model.trafficCountData}}</a>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </article>

--- a/ember/app/utils/filters.js
+++ b/ember/app/utils/filters.js
@@ -45,7 +45,10 @@ const filters = {
   'totalCost': { name: 'Total cost', glossaryKey: 'COST_OF_CONSTRUCTION', type: 'number', ...defaultMetric },
   'parkType': { name: 'Parking type', type: 'string', options: ['garage', 'underground', 'surface', 'other'], ...defaultMetric },
   'descr': { name: 'Description', glossaryKey: 'DESCRIPTION', type: 'string', ...defaultMetric },
-
+  'mepaId': { name: 'MEPA ID', glossaryKey: 'MEPAID', type: 'number', ...defaultMetric },
+  'mepaIdPresent': { name: 'MEPA ID Present', glossaryKey: 'MEPAID_PRESENT', type: 'boolean', ...defaultMetric },
+  'trafficCountData': { name: 'Traffic Count Data', glossaryKey: 'TRAFFIC_COUNT_DATA', type: 'string', ...defaultMetric },
+  'trafficCountDataPresent': { name: 'Traffic Count Data Present', glossaryKey: 'TRAFFIC_COUNT_DATA_PRESENT', type: 'boolean', ...defaultMetric },
   'phased': { name: 'Phased', glossaryKey: 'PHASED', type: 'boolean', ...defaultMetric },
   'stalled': { name: 'Stalled', glossaryKey: 'STALLED', type: 'boolean', ...defaultMetric },
   'stories': { name: 'Stories', glossaryKey: 'STORIES', type: 'number', ...defaultMetric },
@@ -113,6 +116,10 @@ const metricGroups = {
         'rdv',
         'phased',
         'stalled',
+        'mepaId',
+        'mepaIdPresent',
+        'trafficCountData',
+        'trafficCountDataPresent'
       ]
     },
     {

--- a/rails/app/controllers/developments_controller.rb
+++ b/rails/app/controllers/developments_controller.rb
@@ -108,7 +108,8 @@ class DevelopmentsController < ApplicationController
                   :latitude, :longitude, :parcel_id, :mixed_use, :point, :programs, :forty_b, :residential,
                   :commercial, :municipal, :devlper, :yrcomp_est, :units_1bd, :units_2bd, :units_3bd,
                   :affrd_unit, :aff_u30, :aff_30_50, :aff_50_80, :aff_80p, :headqtrs, :park_type, :publicsqft,
-                  :unknownhu, :aff_unknown, :unk_sqft, :flag)
+                  :unknownhu, :aff_unknown, :unk_sqft, :flag, :traffic_count_data_present, :mepa_id_present,
+                  :mepa_id, :traffic_count_data)
   end
 
   # Only allow a trusted parameter "white list" through.
@@ -125,7 +126,7 @@ class DevelopmentsController < ApplicationController
                                                                        latitude longitude parcel_id mixed_use point programs forty_b residential
                                                                        commercial municipal devlper yrcomp_est units_1bd units_2bd units_3bd
                                                                        affrd_unit aff_u30 aff_30_50 aff_50_80 aff_80p headqtrs park_type publicsqft
-                                                                       unknownhu aff_unknown unk_sqft flag])
+                                                                       unknownhu aff_unknown unk_sqft flag mepa_id traffic_count_data mepa_id_present traffic_count_data_present])
       end
     end
   end

--- a/rails/app/models/development.rb
+++ b/rails/app/models/development.rb
@@ -39,6 +39,8 @@ class Development < ApplicationRecord
   end
 
   before_save :update_point
+  before_save :set_traffic_count_data_present
+  before_save :set_mepa_id_present
   after_save :geocode
   after_save :update_rpa
   after_save :update_county
@@ -209,5 +211,13 @@ class Development < ApplicationRecord
     sql_result = ActiveRecord::Base.connection.exec_query(loc_id_query).to_hash[0]
     return if sql_result.blank?
     self.update_columns(loc_id: sql_result['parloc_id'])
+  end
+  
+  def set_mepa_id_present
+    self.mepa_id_present = mepa_id.present?
+  end
+  
+  def set_traffic_count_data_present
+    self.traffic_count_data_present = traffic_count_data.present?
   end
 end

--- a/rails/app/serializers/full_development_serializer.rb
+++ b/rails/app/serializers/full_development_serializer.rb
@@ -14,7 +14,7 @@ class FullDevelopmentSerializer
     :mixed_use, :point, :programs, :forty_b, :residential, :commercial,
     :units_1bd, :units_2bd, :units_3bd, :affrd_unit, :aff_u30, :aff_30_50,
     :aff_50_80, :aff_80p, :headqtrs, :park_type, :publicsqft, :unknownhu,
-    :unk_sqft, :aff_unknown, :updated_at, :flag].each { |attr| attribute attr }
+    :unk_sqft, :aff_unknown, :updated_at, :flag, :mepa_id, :traffic_count_data].each { |attr| attribute attr }
 
   attribute :latitude do |object|
     object.point.try :y

--- a/rails/db/migrate/20210308223859_add_fields_to_developments.rb
+++ b/rails/db/migrate/20210308223859_add_fields_to_developments.rb
@@ -1,0 +1,6 @@
+class AddFieldsToDevelopments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :developments, :mepa_id, :integer
+    add_column :developments, :traffic_count_data, :string
+  end
+end

--- a/rails/db/migrate/20210319190347_add_presence_fields_to_developments.rb
+++ b/rails/db/migrate/20210319190347_add_presence_fields_to_developments.rb
@@ -1,0 +1,6 @@
+class AddPresenceFieldsToDevelopments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :developments, :mepa_id_present, :boolean
+    add_column :developments, :traffic_count_data_present, :boolean
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,12 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201130212232) do
+ActiveRecord::Schema.define(version: 20210319190347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
   enable_extension "postgres_fdw"
+
+  create_table "allpoints_final2", primary_key: "gid", id: :integer, default: nil, force: :cascade do |t|
+    t.decimal "id"
+    t.integer "muni_id"
+    t.string "muni", limit: 18
+    t.string "parloc_id", limit: 20
+    t.decimal "fy", precision: 10
+    t.geometry "geom", limit: {:srid=>26986, :type=>"st_point"}
+    t.index ["geom"], name: "allpoints_final2_geom_idx", using: :gist
+  end
 
   create_table "developments", force: :cascade do |t|
     t.integer "user_id"
@@ -91,8 +101,12 @@ ActiveRecord::Schema.define(version: 20201130212232) do
     t.string "county"
     t.string "nhood"
     t.text "n_transit", default: [], array: true
-    t.boolean "flag"
+    t.boolean "flag", default: false, null: false
     t.datetime "deleted_at"
+    t.integer "mepa_id"
+    t.string "traffic_count_data"
+    t.boolean "mepa_id_present"
+    t.boolean "traffic_count_data_present"
     t.index ["deleted_at"], name: "index_developments_on_deleted_at"
   end
 

--- a/rails/lib/tasks/db.rake
+++ b/rails/lib/tasks/db.rake
@@ -1,26 +1,26 @@
 namespace :db do
   task add_foreign_data_wrapper_interface: :environment do
     ActiveRecord::Base.connection.execute "CREATE EXTENSION IF NOT EXISTS postgres_fdw;"
-    ActiveRecord::Base.connection.execute "CREATE SERVER dblive95 FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'db.live.mapc.org', port '5433', dbname 'postgis');"
-    ActiveRecord::Base.connection.execute "CREATE USER MAPPING FOR CURRENT_USER SERVER dblive95 OPTIONS (user '#{Rails.application.secrets.foreign_database_username}', password '#{Rails.application.secrets.foreign_database_password}');"
+    ActiveRecord::Base.connection.execute "CREATE SERVER IF NOT EXISTS pg FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'pg.mapc.org', port '5432', dbname 'postgis');"
+    ActiveRecord::Base.connection.execute "CREATE USER MAPPING IF NOT EXISTS FOR CURRENT_USER SERVER pg OPTIONS (user '#{Rails.application.secrets.foreign_database_username}', password '#{Rails.application.secrets.foreign_database_password}');"
   end
 
   task delete_foreign_data_wrapper_interface: :environment do
-    ActiveRecord::Base.connection.execute "DROP USER MAPPING IF EXISTS FOR #{ActiveRecord::Base.configurations[Rails.env]['username']} SERVER dblive95"
-    ActiveRecord::Base.connection.execute "DROP SERVER IF EXISTS dblive95"
+    ActiveRecord::Base.connection.execute "DROP USER MAPPING IF EXISTS FOR #{ActiveRecord::Base.configurations[Rails.env]['username']} SERVER pg"
+    ActiveRecord::Base.connection.execute "DROP SERVER IF EXISTS pg"
     ActiveRecord::Base.connection.execute "DROP EXTENSION IF EXISTS postgres_fdw"
   end
 
   task add_rpa_fdw: :environment do
-    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (rpa_poly) FROM SERVER dblive95 INTO public;"
+    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (rpa_poly) FROM SERVER pg INTO public;"
   end
 
   task add_tod_service_area_poly: :environment do
-    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (tod_service_area_poly) FROM SERVER dblive95 INTO public;"
+    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (tod_service_area_poly) FROM SERVER pg INTO public;"
   end
 
   task add_neighborhoods_poly: :environment do
-    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (neighborhoods_poly) FROM SERVER dblive95 INTO public;"
+    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (neighborhoods_poly) FROM SERVER pg INTO public;"
   end
   
   task delete_neighborhoods_poly: :environment do
@@ -36,7 +36,7 @@ namespace :db do
   end
 
   task add_counties_fdw: :environment do
-    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (counties_polym) FROM SERVER dblive95 INTO public;"
+    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (counties_polym) FROM SERVER pg INTO public;"
   end
 
   task delete_counties_fdw: :environment do
@@ -44,7 +44,7 @@ namespace :db do
   end
 
   task add_municipalities_fdw: :environment do
-    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (ma_municipalities) FROM SERVER dblive95 INTO public;"
+    ActiveRecord::Base.connection.execute "IMPORT FOREIGN SCHEMA editor LIMIT TO (ma_municipalities) FROM SERVER pg INTO public;"
   end
 
   task delete_municipalities_fdw: :environment do

--- a/rails/spec/factories/developments.rb
+++ b/rails/spec/factories/developments.rb
@@ -61,5 +61,7 @@ FactoryBot.define do
     park_type { 'parking' }
     publicsqft { 1 }
     yrcomp_est { '2010' }
+    mepa_id { 12345 }
+    traffic_count_data { 'https://mobility-massdot.hub.arcgis.com' }
   end
 end


### PR DESCRIPTION
Resolves # 308.

# Why is this change necessary?
We want to add MEPA ID and Traffic Count Data fields to the development model.

# How does it address the issue?
It does this, along with adding filters, and as a bonus we update our migrations to point to the correct (latest) DB server as well.
